### PR TITLE
Add granular DRA status authorization RBAC rules

### DIFF
--- a/charts/hami-dra/templates/hami-dra-driver/rbac.yaml
+++ b/charts/hami-dra/templates/hami-dra-driver/rbac.yaml
@@ -86,6 +86,13 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceclaims/driver
+  verbs:
+  - associated-node:update
+  - associated-node:patch
+- apiGroups:
   - ""
   resources:
   - nodes


### PR DESCRIPTION
## Summary

- Add `resourceclaims/driver` permission with `associated-node:update` and `associated-node:patch` verbs to the `hami-dra-driver-clusterrole` ClusterRole in `charts/hami-dra/templates/hami-dra-driver/rbac.yaml`

This prepares the driver for the `DRAResourceClaimGranularStatusAuthorization` feature gate, which is beta and on-by-default in Kubernetes v1.36. Since HAMi-DRA is a node-local DRA driver (DaemonSet), the `associated-node:*` verbs are used. These permissions are inert on older Kubernetes versions.

## Test plan

- [x] `helm template` renders without errors
- [x] `kubectl apply --dry-run=client` validates all resources
- [x] Deployed to a kind cluster (v1.35) — ClusterRole created with the new rule, no breakage
- [x] Existing unit tests pass (`go test ./...`)

Ref: kubernetes/kubernetes#138149