### PR TITLE
feat: schedule nvidia dra daemonset on selected gpu nodes

### DIFF
--- a/charts/hami-dra/templates/hami-dra-driver/nvidia-dra-driver-daemonset.yaml
+++ b/charts/hami-dra/templates/hami-dra-driver/nvidia-dra-driver-daemonset.yaml
@@ -17,6 +17,20 @@ spec:
         hami-dra-driver-component: kubelet-plugin
     spec:
       {{- include "hami.dra.driver.nvidia.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.drivers.nvidia.daemonSet }}
+      {{- with .Values.drivers.nvidia.daemonSet.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.drivers.nvidia.daemonSet.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.drivers.nvidia.daemonSet.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
       initContainers:
       - name: init-container
         image: {{ include "hami.dra.driver.nvidia.image" . }}

--- a/charts/hami-dra/values.yaml
+++ b/charts/hami-dra/values.yaml
@@ -155,6 +155,12 @@ certs:
 drivers:
   nvidia:
     enabled: true
+    daemonSet:
+      nodeSelector:
+        gpu: "on"
+      tolerations: []
+      affinity: {}
+      
     # If you are using gpu driver on host, you need to set this to false
     containerDriver: true
     image:


### PR DESCRIPTION
Fixes #17

This PR updates the Helm chart to ensure the NVIDIA DRA DaemonSet only runs on intended GPU nodes, preventing resource waste and log spam on CPU-only nodes. 

Changes made:
- Added a `daemonSet` configuration block under `drivers.nvidia` in `values.yaml` to support `nodeSelector`, `tolerations`, and `affinity`.
- Set the default `nodeSelector` to `gpu: "on"` to align with existing HAMi documentation.
- Updated `nvidia-dra-driver-daemonset.yaml` to inject these scheduling rules if they are defined.

Testing:
- Verified YAML rendering locally using `helm template` to ensure proper syntax and indentation.