### PR TITLE
fix: remove repeated labels in templates/webhook/device-config.yaml

### DIFF
--- a/charts/hami-dra/Chart.yaml
+++ b/charts/hami-dra/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.1"
+appVersion: "0.2.2"
 
 keywords:
   - webhook

--- a/charts/hami-dra/templates/webhook/device-config.yaml
+++ b/charts/hami-dra/templates/webhook/device-config.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ include "hami.dra.webhook.fullname" . }}-device-config
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/component: hami-scheduler
     {{- include "hami-dra-webhook.selectorLabels" . | nindent 4 }}
 data:
   device-config.yaml: |-


### PR DESCRIPTION
# Summary
* fix #26 

# Changes Made
* remove repeated key `app.kubernetes.io/component: hami-scheduler` in `templates/webhook/device-config.yaml`
