### PR TITLE
fix: replace panic with error return in webhook kubeconfig loading

### DIFF
--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -133,7 +133,7 @@ func Run(ctx context.Context, opts *options.Options) error {
 
 	config, err := controllerruntime.GetConfig()
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to get kubeconfig: %w", err)
 	}
 	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(opts.KubeAPIQPS, opts.KubeAPIBurst)
 


### PR DESCRIPTION
When `controllerruntime.GetConfig()` fails, the webhook server panics instead of returning an error. This causes an ungraceful crash with no structured logging.

Replace `panic(err)` with `return fmt.Errorf(...)` so the error propagates normally.