### PR TITLE
fix: use device Name instead of UUID for deviceIdx lookup in metrics

### DIFF
--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -126,7 +126,7 @@ func (c *Collector) collectPodMetrics(ch chan<- prometheus.Metric) {
 				deviceBrand = device.Brand
 				deviceProductName = device.ProductName
 				for idx, d := range devices {
-					if d.UUID == result.DeviceName {
+					if d.Name == result.DeviceName {
 						deviceIdx = strconv.Itoa(idx)
 						break
 					}


### PR DESCRIPTION
In `collectPodMetrics`, `deviceIdx` is looked up by comparing `d.UUID == result.DeviceName`. Since `result.DeviceName` holds the device name (not UUID), this comparison never matches and `deviceIdx` is always reported as `"0"`.

Fix: use `d.Name == result.DeviceName`, consistent with the outer loop above it.