### PR TITLE
chore: remove unused RegisterMetrics function

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -51,6 +51,3 @@ var (
 	)
 )
 
-func RegisterMetrics(collector *Collector) {
-	prometheus.MustRegister(collector)
-}


### PR DESCRIPTION
`RegisterMetrics` in `pkg/metrics/metrics.go` is never called anywhere in the codebase. The collector is registered via `customRegistry.MustRegister` in `monitor.go`. Remove the dead function.