### PR TITLE
fix: reset device pointer per result in collectPodMetrics

### DIFF
--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -108,8 +108,8 @@ func (c *Collector) collectPodMetrics(ch chan<- prometheus.Metric) {
 
 	for _, claim := range claims {
 		devices := c.cache.NodeDevices.GetDevices(claim.NodeName)
-		var device *cache.NodeDevice
 		for _, result := range claim.AllocationResults {
+			var device *cache.NodeDevice
 			for _, d := range devices {
 				if d.Name == result.DeviceName {
 					device = d


### PR DESCRIPTION
In `collectPodMetrics`, `device` was declared outside the inner `result` loop.

If a claim has multiple allocation results and one device lookup fails, `device` still holds the value from the previous iteration. Wrong device data is then used for that result's metrics.

Move `var device *cache.NodeDevice` inside the `result` loop so it resets to `nil` on each iteration.