### PR TITLE
fix: correct log message ResourceClaim to ResourceClaimTemplate in volcano validating webhook

### DIFF
--- a/pkg/webhook/volcano/validating.go
+++ b/pkg/webhook/volcano/validating.go
@@ -61,7 +61,7 @@ func (v *ValidatingAdmission) Handle(ctx context.Context, req admission.Request)
 			},
 		})
 		if err != nil && !apierrors.IsNotFound(err) {
-			klog.Warningf("Failed to delete ResourceClaim %s/%s: %v", job.Namespace, resourceClaimName, err)
+			klog.Warningf("Failed to delete ResourceClaimTemplate %s/%s: %v", job.Namespace, resourceClaimName, err)
 			continue
 		}
 	}


### PR DESCRIPTION
The warning log on delete failure said `ResourceClaim` but the volcano validating webhook deletes `ResourceClaimTemplate` objects. The log message was misleading.