### PR TITLE
fix: remove spurious word memory from GPUDeviceCoreLimit description

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -26,7 +26,7 @@ var (
 	)
 	nodevGPUCoreLimitDesc = prometheus.NewDesc(
 		"GPUDeviceCoreLimit",
-		"Device memory core limit for a certain GPU",
+		"Device core limit for a certain GPU",
 		[]string{"nodeid", "deviceuuid", "deviceidx", "devicename", "devicebrand", "deviceproductname"}, nil,
 	)
 	nodevGPUMemoryAllocatedDesc = prometheus.NewDesc(


### PR DESCRIPTION
The help string for `GPUDeviceCoreLimit` read "Device memory core limit" which is incorrect. It describes core limit, not memory. Remove the extra word.