### PR TITLE
fix: truncate ResourceClaim name to stay within 253 char limit

### DIFF
--- a/pkg/webhook/dra/mutating.go
+++ b/pkg/webhook/dra/mutating.go
@@ -18,6 +18,7 @@ package dra
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -114,9 +115,11 @@ func (a *MutatingAdmission) handelContainer(ctx context.Context, container *core
 
 	rcName := fmt.Sprintf("%s-%s-%s", pod.Namespace, pod.Name, container.Name)
 	if pod.Name == "" {
-		// Use random string when pod name is empty to ensure unique resource claim names.
-		// Note: This addresses part of the original TODO about handling empty pod names.
 		rcName = fmt.Sprintf("%s-%s-%s", pod.Namespace, rand.String(5), container.Name)
+	}
+	if len(rcName) > 253 {
+		h := sha256.Sum256([]byte(rcName))
+		rcName = fmt.Sprintf("%s-%x", rcName[:220], h[:4])
 	}
 
 	var podToOwn *corev1.Pod


### PR DESCRIPTION
Volcano mutating webhook already truncates ResourceClaimTemplate names
when they exceed 253 chars. 
The DRA mutating webhook had the same issue
but no truncation logic. 
This adds the same sha256-based truncation to `handelContainer` so
ResourceClaim names also stay within the Kubernetes name length limit.