### PR TITLE
fix: handle DeletedFinalStateUnknown in cache delete handlers

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -149,7 +149,14 @@ func (c *Cache) onUpdateClaim(oldObj, newObj interface{}) {
 func (c *Cache) onDeleteClaim(obj interface{}) {
 	claim, ok := obj.(*resourceapi.ResourceClaim)
 	if !ok {
-		return
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return
+		}
+		claim, ok = tombstone.Obj.(*resourceapi.ResourceClaim)
+		if !ok {
+			return
+		}
 	}
 	c.NodeDevices.onDeleteClaim(claim)
 }
@@ -235,7 +242,14 @@ func (c *Cache) onUpdateSlice(oldObj, newObj interface{}) {
 func (c *Cache) onDeleteSlice(obj interface{}) {
 	slice, ok := obj.(*resourceapi.ResourceSlice)
 	if !ok {
-		return
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return
+		}
+		slice, ok = tombstone.Obj.(*resourceapi.ResourceSlice)
+		if !ok {
+			return
+		}
 	}
 	if slice.Spec.NodeName == nil {
 		klog.Warningf("ResourceSlice %s has no node name, skipping delete", slice.Name)


### PR DESCRIPTION
When a watch event is missed (e.g. during controller restart), the
informer wraps the last known object in `cache.DeletedFinalStateUnknown`.

Both `onDeleteClaim` and `onDeleteSlice` did a direct type assertion
and silently returned on failure, so these tombstone events were dropped.

This left stale device usage in the in-memory cache until the next restart.

The fix adds the standard tombstone unwrap pattern to both handlers,
matching the approach used across the k8s controller ecosystem.