### PR TITLE
fix: remove unsafe nil check around sync.Once in FeatureGates

### DIFF
--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -63,11 +63,9 @@ func FeatureGates() featuregate.MutableVersionedFeatureGate {
 		}
 	}
 
-	if featureGates == nil {
-		featureGatesOnce.Do(func() {
-			featureGates = newFeatureGates(relVer.Version)
-		})
-	}
+	featureGatesOnce.Do(func() {
+		featureGates = newFeatureGates(relVer.Version)
+	})
 	return featureGates
 }
 


### PR DESCRIPTION
The `FeatureGates()` function had an unsynchronized read of `featureGates` outside `sync.Once`