### PR TITLE
fix: make Cache.ready an atomic.Bool to fix data race

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"fmt"
 	"reflect"
+	"sync/atomic"
 	"time"
 
 	"github.com/Project-HAMi/HAMi-DRA/pkg/utils"
@@ -37,7 +38,7 @@ type Cache struct {
 	kubeClient  kubernetes.Interface
 	sliceLister listersresourcev1.ResourceSliceLister
 	claimLister listersresourcev1.ResourceClaimLister
-	ready       bool
+	ready       atomic.Bool
 }
 
 // NewCache creates a new Cache with a Kubernetes client.
@@ -57,7 +58,6 @@ func NewCache() *Cache {
 func NewCacheWithClient(kubeClient kubernetes.Interface) *Cache {
 	return &Cache{
 		stopCh:      make(chan struct{}),
-		ready:       false,
 		NodeDevices: NewNodeDevices(),
 		kubeClient:  kubeClient,
 	}
@@ -111,19 +111,19 @@ func (c *Cache) Start() error {
 	}
 	klog.V(5).Info("ResourceClaim cache synced successfully")
 
-	c.ready = true
+	c.ready.Store(true)
 	klog.Infof("Cache started and synced successfully")
 	return nil
 }
 
 func (c *Cache) Stop() {
 	close(c.stopCh)
-	c.ready = false
+	c.ready.Store(false)
 	klog.Infof("Cache stopped")
 }
 
 func (c *Cache) IsReady() bool {
-	return c.ready
+	return c.ready.Load()
 }
 
 func (c *Cache) onAddClaim(obj interface{}) {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -42,7 +42,7 @@ func TestNewCache(t *testing.T) {
 	if c.stopCh == nil {
 		t.Error("stopCh should not be nil")
 	}
-	if c.ready {
+	if c.ready.Load() {
 		t.Error("Cache should not be ready initially")
 	}
 }
@@ -144,7 +144,6 @@ func TestCache_onAddSlice(t *testing.T) {
 	c := &Cache{
 		NodeDevices: NewNodeDevices(),
 		stopCh:      make(chan struct{}),
-		ready:       false,
 	}
 
 	nodeName := "test-node"
@@ -183,7 +182,6 @@ func TestCache_onUpdateSlice(t *testing.T) {
 	c := &Cache{
 		NodeDevices: NewNodeDevices(),
 		stopCh:      make(chan struct{}),
-		ready:       false,
 	}
 
 	nodeName := "test-node"
@@ -218,7 +216,6 @@ func TestCache_onDeleteSlice(t *testing.T) {
 	c := &Cache{
 		NodeDevices: NewNodeDevices(),
 		stopCh:      make(chan struct{}),
-		ready:       false,
 	}
 
 	nodeName := "test-node"
@@ -253,7 +250,6 @@ func TestCache_onAddSlice_NoNodeName(t *testing.T) {
 	c := &Cache{
 		NodeDevices: NewNodeDevices(),
 		stopCh:      make(chan struct{}),
-		ready:       false,
 	}
 
 	// Create slice without node name
@@ -299,7 +295,6 @@ func TestCache_onAddClaim_NoAllocation(t *testing.T) {
 	c := &Cache{
 		NodeDevices: NewNodeDevices(),
 		stopCh:      make(chan struct{}),
-		ready:       false,
 	}
 
 	// Create claim without allocation
@@ -340,7 +335,6 @@ func TestCache_onAddClaim_WithAllocation(t *testing.T) {
 	c := &Cache{
 		NodeDevices: NewNodeDevices(),
 		stopCh:      make(chan struct{}),
-		ready:       false,
 	}
 
 	// First add a device
@@ -396,7 +390,6 @@ func TestCache_onDeleteClaim(t *testing.T) {
 	c := &Cache{
 		NodeDevices: NewNodeDevices(),
 		stopCh:      make(chan struct{}),
-		ready:       false,
 	}
 
 	// First add a device
@@ -451,7 +444,6 @@ func TestCache_onUpdateClaim(t *testing.T) {
 	c := &Cache{
 		NodeDevices: NewNodeDevices(),
 		stopCh:      make(chan struct{}),
-		ready:       false,
 	}
 
 	// First add a device
@@ -486,14 +478,13 @@ func TestCache_IsReady(t *testing.T) {
 	c := &Cache{
 		NodeDevices: NewNodeDevices(),
 		stopCh:      make(chan struct{}),
-		ready:       false,
 	}
 
 	if c.IsReady() {
 		t.Error("Cache should not be ready initially")
 	}
 
-	c.ready = true
+	c.ready.Store(true)
 	if !c.IsReady() {
 		t.Error("Cache should be ready after setting ready to true")
 	}


### PR DESCRIPTION
## What

Change `Cache.ready` from plain `bool` to `atomic.Bool`.

## Why

`Start()` and `Stop()` write `ready` while the `/readyz` handler reads it from another goroutine via `IsReady()`. This is a data race.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache readiness tracking to be safe for concurrent use.
  * Cache startup and shutdown now update readiness more reliably, reducing the chance of inconsistent state.
  * Tests were updated to match the new readiness handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->