### PR TITLE
fix(webhook): handle every GPU container in a task and keep existing claims

### DIFF
--- a/pkg/webhook/dra/mutating.go
+++ b/pkg/webhook/dra/mutating.go
@@ -68,7 +68,7 @@ func (a *MutatingAdmission) Handle(ctx context.Context, req admission.Request) a
 		if rcName != "" {
 			needPatch = true
 			rcNameList = append(rcNameList, rcName)
-			container.Resources.Claims = []corev1.ResourceClaim{{Name: rcName}}
+			container.Resources.Claims = append(container.Resources.Claims, corev1.ResourceClaim{Name: rcName})
 			pod.Spec.ResourceClaims = append(pod.Spec.ResourceClaims, corev1.PodResourceClaim{
 				Name:              rcName,
 				ResourceClaimName: &rcName,

--- a/pkg/webhook/volcano/mutating.go
+++ b/pkg/webhook/volcano/mutating.go
@@ -60,11 +60,11 @@ func (a *MutatingAdmission) Handle(ctx context.Context, req admission.Request) a
 
 	for i := range job.Spec.Tasks {
 		task := &job.Spec.Tasks[i]
-		rctName, err := a.handleTask(ctx, task, job)
+		rctNames, err := a.handleTask(ctx, task, job)
 		if err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
-		if rctName != "" {
+		for _, rctName := range rctNames {
 			needPatch = true
 			rctNameList = append(rctNameList, rctName)
 			task.Template.Spec.ResourceClaims = append(task.Template.Spec.ResourceClaims, corev1.PodResourceClaim{
@@ -103,18 +103,21 @@ func (a *MutatingAdmission) Handle(ctx context.Context, req admission.Request) a
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledBytes)
 }
 
-func (a *MutatingAdmission) handleTask(ctx context.Context, task *vcv1alpha1.TaskSpec, job *vcv1alpha1.Job) (string, error) {
+// handleTask processes every container in the task and returns the names of
+// the ResourceClaimTemplates created for them.
+func (a *MutatingAdmission) handleTask(ctx context.Context, task *vcv1alpha1.TaskSpec, job *vcv1alpha1.Job) ([]string, error) {
+	var rctNames []string
 	for i := range task.Template.Spec.Containers {
 		container := &task.Template.Spec.Containers[i]
 		rctName, err := a.handleContainerTemplate(ctx, container, job.Namespace, task.Name)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 		if rctName != "" {
-			return rctName, nil
+			rctNames = append(rctNames, rctName)
 		}
 	}
-	return "", nil
+	return rctNames, nil
 }
 
 func (a *MutatingAdmission) handleContainerTemplate(ctx context.Context, container *corev1.Container, namespace, name string) (string, error) {

--- a/pkg/webhook/volcano/mutating_test.go
+++ b/pkg/webhook/volcano/mutating_test.go
@@ -154,6 +154,55 @@ func TestMutatingAdmission_Handle(t *testing.T) {
 	}
 }
 
+func TestHandleTaskProcessesAllContainers(t *testing.T) {
+	sch := runtime.NewScheme()
+	require.NoError(t, scheme.AddToScheme(sch))
+	require.NoError(t, vcv1alpha1.AddToScheme(sch))
+
+	fakeClient := fake.NewClientBuilder().WithScheme(sch).Build()
+
+	admission := &MutatingAdmission{
+		Client: fakeClient,
+		DeviceConfig: &config.DRADeviceConfig{
+			ResourceCountName:  "nvidia.com/gpu",
+			ResourceMemoryName: "nvidia.com/gpumem",
+			ResourceCoreName:   "nvidia.com/gpucores",
+			RequestName:        "gpu",
+		},
+	}
+
+	gpuResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+		},
+	}
+	task := &vcv1alpha1.TaskSpec{
+		Name: "multi-gpu-task",
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "gpu-one", Resources: *gpuResources.DeepCopy()},
+					{Name: "cpu-only"},
+					{Name: "gpu-two", Resources: *gpuResources.DeepCopy()},
+				},
+			},
+		},
+	}
+	job := &vcv1alpha1.Job{ObjectMeta: metav1.ObjectMeta{Name: "multi", Namespace: "default"}}
+
+	rctNames, err := admission.handleTask(context.Background(), task, job)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"default-multi-gpu-task-gpu-one", "default-multi-gpu-task-gpu-two"}, rctNames)
+
+	for _, i := range []int{0, 2} {
+		container := task.Template.Spec.Containers[i]
+		assert.NotContains(t, container.Resources.Limits, corev1.ResourceName("nvidia.com/gpu"),
+			"GPU count resource should be removed from container %s", container.Name)
+		require.Len(t, container.Resources.Claims, 1, "container %s should reference a claim", container.Name)
+	}
+	assert.Empty(t, task.Template.Spec.Containers[1].Resources.Claims, "cpu-only container should be untouched")
+}
+
 func TestBuildResourceClaimTemplateUsesConfiguredDriver(t *testing.T) {
 	admission := &MutatingAdmission{
 		DeviceConfig: &config.DRADeviceConfig{


### PR DESCRIPTION
## What

- Volcano `handleTask` now processes all containers in a task and creates one ResourceClaimTemplate per GPU container. Before, it returned after the first one, so a second GPU container kept its device-plugin resources and got no claim, and its pod could not schedule.
- DRA pod webhook now appends to `container.Resources.Claims` instead of replacing the list, same as the Volcano path. User-defined claims are no longer dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support now extends to multiple resource claims per task, allowing all matching containers to be processed.
* **Bug Fixes**
  * Existing resource claims on containers are now preserved instead of being overwritten.
  * Tasks with more than one eligible container now receive the correct claim entries for each container.
  * CPU-only containers remain unchanged during admission handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->