### PR TITLE
chore: fix log arguments, comment typos, remove dead code

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,7 +114,7 @@ type HygonConfig struct {
 }
 
 type NvidiaConfig struct {
-	// These configs are shared and can be overritten by Nodeconfig.
+	// These configs are shared and can be overwritten by Nodeconfig.
 	NodeDefaultConfig            `yaml:",inline"`
 	ResourceCountName            string `yaml:"resourceCountName"`
 	ResourceMemoryName           string `yaml:"resourceMemoryName"`
@@ -134,20 +134,6 @@ type NvidiaConfig struct {
 	GPUCorePolicy GPUCoreUtilizationPolicy `yaml:"gpuCorePolicy"`
 	// RuntimeClassName is the name of the runtime class to be added to pod.spec.runtimeClassName
 	RuntimeClassName string `yaml:"runtimeClassName"`
-}
-
-func (c *NvidiaConfig) EffectiveDeviceClassName() string {
-	if c != nil && c.DeviceClassName != "" {
-		return c.DeviceClassName
-	}
-	return "hami-core-gpu.project-hami.io"
-}
-
-func (c *NvidiaConfig) EffectiveDraDriverName() string {
-	if c != nil && c.DraDriverName != "" {
-		return c.DraDriverName
-	}
-	return "hami-core-gpu.project-hami.io"
 }
 
 // NodeDefaultConfig defines settings that can be specified per node via Nodeconfig.
@@ -172,7 +158,7 @@ type FilterDevice struct {
 
 type DevicePluginConfigs struct {
 	Nodeconfig []struct {
-		// These configs is shared and will overrite those in NvidiaConfig.
+		// These configs are shared and will overwrite those in NvidiaConfig.
 		NodeDefaultConfig `json:",inline"`
 		Name              string        `json:"name"`
 		OperatingMode     string        `json:"operatingmode"`

--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -119,7 +119,7 @@ func (c *Collector) collectPodMetrics(ch chan<- prometheus.Metric) {
 				}
 			}
 			if device == nil {
-				klog.Warningf("Device %s not found for claim %s", result.DeviceName, claim.NodeName)
+				klog.Warningf("Device %s not found on node %s", result.DeviceName, claim.NodeName)
 				continue
 			}
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -50,4 +50,3 @@ var (
 		[]string{"nodeid", "deviceuuid", "deviceidx", "devicename", "devicebrand", "deviceproductname", "podnamespace", "podname"}, nil,
 	)
 )
-

--- a/pkg/webhook/dra/mutating.go
+++ b/pkg/webhook/dra/mutating.go
@@ -98,7 +98,7 @@ func (a *MutatingAdmission) Handle(ctx context.Context, req admission.Request) a
 				},
 			})
 			if deletionErr != nil {
-				klog.V(5).Infof("Failed to delete ResourceClaim(%s/%s) for request: %s after an error occurs", pod.Namespace, pod.Name, req.Operation)
+				klog.V(5).Infof("Failed to delete ResourceClaim(%s/%s) for request: %s after an error occurs", pod.Namespace, rcName, req.Operation)
 			}
 		}
 		return admission.Errored(http.StatusInternalServerError, err)


### PR DESCRIPTION
## What

- `collector.go`: log said "not found for claim %s" but printed the node name; reword to "not found on node %s".
- `dra/mutating.go`: cleanup log printed the pod name where the ResourceClaim name belongs.
- `config.go`: fix "overritten" and "overrite" comment typos.
- Remove unused `NvidiaConfig.EffectiveDeviceClassName` and `EffectiveDraDriverName`; all callers use the `DRADeviceConfig` methods.
- gofmt `pkg/metrics/metrics.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log messages to better identify affected devices and resources during claim handling and cleanup.
* **Documentation**
  * Corrected and clarified configuration comments for shared NVIDIA settings and node-specific overrides.
* **Refactor**
  * Removed built-in fallback behavior for certain NVIDIA configuration values, so defaults are now handled elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->