### PR TITLE
fix(chart): align appVersion with published images, fix ghcr registry path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ifneq ($(GOARCH),amd64)
 endif
 endif
 
-REGISTRY_REPO?="ghcr.io/projecthami"
+REGISTRY_REPO?="ghcr.io/project-hami"
 
 .PHONY: build build-monitor build-fake-driver docker-build docker-build-monitor docker-build-fake-driver test test-quick test-coverage clean run run-monitor run-fake-driver license license-check fmt lint
 

--- a/charts/hami-dra/Chart.yaml
+++ b/charts/hami-dra/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.3"
+appVersion: "0.2.1"
 
 keywords:
   - webhook

--- a/charts/hami-dra/dcu-values.yaml
+++ b/charts/hami-dra/dcu-values.yaml
@@ -26,7 +26,7 @@ drivers:
 
 webhook:
   image:
-    registry: ghcr.io/projecthami
+    registry: ghcr.io/project-hami
     repository: hami-dra-webhook
     tag: dcu
     pullPolicy: IfNotPresent

--- a/charts/hami-dra/values.yaml
+++ b/charts/hami-dra/values.yaml
@@ -54,7 +54,7 @@ webhook:
   image:
     registry: ghcr.io
     repository: project-hami/hami-dra-webhook
-    tag: "v0.2.0"
+    tag: "v0.2.1"
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -104,7 +104,7 @@ monitor:
   image:
     registry: ghcr.io
     repository: project-hami/hami-dra-monitor
-    tag: "v0.2.0"
+    tag: "v0.2.1"
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
## What

- `appVersion` was "0.2.3" but no such image exists on ghcr.io; the latest published webhook and monitor images are `v0.2.1`. Bump pinned image tags to `v0.2.1`, set `appVersion` to "0.2.1", bump chart version to 0.2.4.
- `dcu-values.yaml` and the Makefile pointed at `ghcr.io/projecthami`, but CI publishes under `ghcr.io/project-hami`. Fixed. The `docker.io/projecthami` path is unchanged because that Docker Hub org name has no hyphen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image references to the new repository path.
  * Bumped the Helm chart release version and application version.
  * Updated bundled component image versions for the webhook and monitor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->