### PR TITLE
fix(chart): make the webhook work without cert-manager

### DIFF
--- a/charts/hami-dra/Chart.yaml
+++ b/charts/hami-dra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hami-dra/templates/webhook/cert-secret.yaml
+++ b/charts/hami-dra/templates/webhook/cert-secret.yaml
@@ -1,13 +1,13 @@
-{{- if eq .Values.certs.mode "custom" }}
+{{- if not .Values.certs.certManager.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "hami-dra-webhook.tlsSecretName" . }}
+  name: {{ .Release.Name }}-tls
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hami-dra-webhook.labels" . | nindent 4 }}
 type: kubernetes.io/tls
 data:
-  tls.crt: |
-    {{- .Values.certs.custom.crt | b64enc | indent 4 }}
-  tls.key: |
-    {{- .Values.certs.custom.key | b64enc | indent 4 }}
+  tls.crt: {{ required "certs.custom.crt is required when certManager is disabled" .Values.certs.custom.crt | b64enc }}
+  tls.key: {{ required "certs.custom.key is required when certManager is disabled" .Values.certs.custom.key | b64enc }}
 {{- end }}

--- a/charts/hami-dra/templates/webhook/mutatingwebhookconfiguration.yaml
+++ b/charts/hami-dra/templates/webhook/mutatingwebhookconfiguration.yaml
@@ -7,8 +7,10 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ .Release.Name }}-mutatingwebhookconfiguration
+{{- if .Values.certs.certManager.enabled }}
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-dra-webhook-serving-cert
+{{- end }}
 webhooks:
   - name: mutate.hami.io
     admissionReviewVersions: ["v1"]

--- a/charts/hami-dra/templates/webhook/validatingwebhookconfiguration.yaml
+++ b/charts/hami-dra/templates/webhook/validatingwebhookconfiguration.yaml
@@ -7,8 +7,10 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ .Release.Name }}-validatingwebhookconfiguration
+{{- if .Values.certs.certManager.enabled }}
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Release.Name }}-dra-webhook-serving-cert
+{{- end }}
 webhooks:
   - name: validate.hami.io
     admissionReviewVersions: ["v1"]

--- a/charts/hami-dra/values.yaml
+++ b/charts/hami-dra/values.yaml
@@ -144,11 +144,11 @@ monitor:
 
 # Certificate configuration
 certs:
-  # Custom certificate (used when mode is "custom")
+  # Custom certificate (used when certManager.enabled is false)
   custom:
     crt: ""
     key: ""
-  # Cert-manager configuration (used when mode is "cert-manager")
+  # Cert-manager configuration
   certManager:
     enabled: true
     # Private key rotation policy: "Never" or "Always"


### PR DESCRIPTION
With `certs.certManager.enabled=false` the Deployment mounted a Secret named `<release>-tls` that no template created, so the pod stayed in ContainerCreating. Render that Secret from `certs.custom.crt/key` when cert-manager is off, and fail with a clear message when they are empty.

`cert-secret.yaml` was gated on `certs.mode`, a key that does not exist in values.yaml, and called an undefined helper. Setting `certs.mode=custom` made `helm template` fail. Both removed.

The `cert-manager.io/inject-ca-from` annotation was emitted even when cert-manager is disabled. Now it renders only when it is enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **Bug Fixes**
  - Webhook TLS/CA behavior now consistently follows the certificate-manager enabled/disabled setting.
  - Webhook TLS Secret is rendered only when certificate-manager is disabled, with certificate values enforced as required.
  - cert-manager CA injection annotations are added only when certificate-manager is enabled.
- **Documentation**
  - Updated chart comments to clarify when custom certificates apply.
- **Chores**
  - Bumped the chart version to **0.2.5**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->