### PR TITLE
fix(chart): lint and label cleanups

### DIFF
--- a/charts/hami-dra/Chart.yaml
+++ b/charts/hami-dra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hami-dra/templates/hami-dra-driver/rbac.yaml
+++ b/charts/hami-dra/templates/hami-dra-driver/rbac.yaml
@@ -5,30 +5,25 @@ metadata:
   name: hami-dra-driver-service-account
   namespace: {{ .Release.Namespace }}
 ---
-apiVersion: v1
-items:
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: Role
-  metadata:
-    name: hami-dra-driver-role
-    namespace: {{ .Release.Namespace }}
-  rules:
-  - apiGroups:
-    - apps
-    resources:
-    - daemonsets
-    - deployments
-    verbs:
-    - get
-    - list
-    - watch
-    - create
-    - update
-    - patch
-    - delete
-kind: List
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
 metadata:
-  resourceVersion: ""
+  name: hami-dra-driver-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/hami-dra/templates/monitor/monitor-deployment.yaml
+++ b/charts/hami-dra/templates/monitor/monitor-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ include "hami.dra.monitor.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "hami.dra.monitor.fullname" . }}
     {{- include "hami-dra-monitor.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.monitor.replicas | default 1 }}

--- a/charts/hami-dra/templates/webhook/webhook-deployment.yaml
+++ b/charts/hami-dra/templates/webhook/webhook-deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ include "hami.dra.webhook.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "hami.dra.webhook.fullname" . }}
     {{- include "hami-dra-webhook.labels" . | nindent 4 }}
 spec:
   replicas: 1

--- a/charts/hami-dra/values.yaml
+++ b/charts/hami-dra/values.yaml
@@ -78,9 +78,6 @@ webhook:
       cpu: 100m
       memory: 128Mi
   ## @param nodeSelector controllerManager node labels for pod assignment
-  args:
-    webhookName: ""  # Default: {{ .Release.Name }}-hami-dra-webhook
-    secretName: ""  # Default: {{ .Release.Name }}-hami-dra-webhook-tls
   # Webhook configuration
   config:
     mutating:


### PR DESCRIPTION
Unwrap the driver Role from a kubectl-style `kind: List` wrapper. The nameless List object caused the `helm lint` name warning.

Drop the duplicate `app.kubernetes.io/name` label key in the webhook and monitor Deployments. The labels helper already sets it and duplicate keys are rejected by strict linters.

Remove `webhook.args.webhookName` and `secretName` from values.yaml. No template reads them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Chores**
  * Updated the chart’s RBAC rendering to emit a Kubernetes `Role` directly instead of wrapping it in a list structure.
  * Standardized Deployment labels for the monitor and webhook using shared label helpers.
  * Removed default webhook argument values from chart settings to avoid preset webhook configuration.
  * Bumped the chart version from `0.2.4` to `0.2.6`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->