### PR TITLE
fix(make): use KUBECONFIG env in run-monitor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,7 @@ run: build
 
 # Run monitor locally (requires kubeconfig)
 run-monitor: build-monitor
-	./bin/monitor \
-		--kubeconfig=$$HOME/.kube/config \
+	KUBECONFIG=$$HOME/.kube/config ./bin/monitor \
 		--metrics-bind-address=:8080 \
 		--health-probe-bind-address=:8000
 


### PR DESCRIPTION
The monitor accepts a `--kubeconfig` flag but never reads it. The client in `pkg/utils/client.go` reads the `KUBECONFIG` env var. Pointing the flag at another file silently did nothing. Pass the env var instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the monitor run command to use the standard Kubernetes config from your home directory, improving local startup and reducing configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->