### PR TITLE
fix(license): stop rewriting valid headers, sync year with template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ cert:
 license:
 	@if command -v addlicense >/dev/null 2>&1; then \
 		echo "Using addlicense tool..."; \
-		addlicense -c "The HAMi Authors" -l apache -y 2025 -s -f .license-header.txt .; \
+		addlicense -c "The HAMi Authors" -l apache -y 2026 -s -f .license-header.txt .; \
 	else \
 		echo "addlicense not found, using script..."; \
 		echo "To install addlicense: ./scripts/install-addlicense.sh"; \
@@ -155,7 +155,7 @@ license:
 # Check license headers (dry-run with addlicense)
 license-check:
 	@if command -v addlicense >/dev/null 2>&1; then \
-		addlicense -c "The HAMi Authors" -l apache -y 2025 -s -f .license-header.txt -check .; \
+		addlicense -c "The HAMi Authors" -l apache -y 2026 -s -f .license-header.txt -check .; \
 	else \
 		echo "addlicense not found. Install it with: ./scripts/install-addlicense.sh"; \
 		exit 1; \

--- a/scripts/add-license.sh
+++ b/scripts/add-license.sh
@@ -11,8 +11,8 @@ LICENSE_TEXT=$(cat "$LICENSE_HEADER")
 # Function to check if file has the correct license header (with correct year)
 has_correct_license() {
     local file=$1
-    # Check if file has "Copyright 2025 The HAMi Authors"
-    if head -n 20 "$file" | grep -q "Copyright 2025.*The HAMi Authors"; then
+    # Accept any year so existing headers are not rewritten
+    if head -n 20 "$file" | grep -q "Copyright 20[0-9][0-9].*The HAMi Authors"; then
         return 0
     fi
     return 1


### PR DESCRIPTION
`scripts/add-license.sh` only accepted `Copyright 2025` while `.license-header.txt` says 2026, so every file with a correct 2026 header was rewritten on each run. Accept any year so existing headers stay as they are. Also update the `addlicense -y` value in the Makefile to match the template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved license header checks so files with a valid year from the 2020s are no longer rewritten unnecessarily.
* **Chores**
  * Updated license-related maintenance tasks to use the current year.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->