### PR TITLE
fix(ci): match setup-go version with go.mod

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25.0'
           cache-dependency-path: go.sum
 
       - name: Download dependencies
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25.0'
           cache-dependency-path: go.sum
 
       - name: Run golangci-lint


### PR DESCRIPTION
go.mod requires go 1.25.0 but CI pinned setup-go to 1.24. It only worked because `GOTOOLCHAIN: go1.25.0+auto` downloaded the right toolchain on every run. Pin setup-go to 1.25.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go version used by automated testing and linting to the latest supported release, helping keep CI checks current and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->