### PR TITLE
fix(monitor): apply kube-api-qps and kube-api-burst flags

### DIFF
--- a/cmd/monitor/app/monitor.go
+++ b/cmd/monitor/app/monitor.go
@@ -35,6 +35,7 @@ import (
 	"github.com/Project-HAMi/HAMi-DRA/cmd/monitor/app/options"
 	"github.com/Project-HAMi/HAMi-DRA/pkg/cache"
 	"github.com/Project-HAMi/HAMi-DRA/pkg/metrics"
+	"github.com/Project-HAMi/HAMi-DRA/pkg/utils"
 	"github.com/Project-HAMi/HAMi-DRA/pkg/version"
 	"github.com/Project-HAMi/HAMi-DRA/pkg/version/sharedcommand"
 )
@@ -108,7 +109,12 @@ func Run(ctx context.Context, opts *options.Options) error {
 
 	// Initialize cache
 	klog.Info("Initializing cache...")
-	cacheInstance := cache.NewCache()
+	client, err := utils.NewClientWithRateLimit(opts.KubeAPIQPS, opts.KubeAPIBurst)
+	if err != nil {
+		klog.Errorf("Failed to create Kubernetes client: %v", err)
+		return err
+	}
+	cacheInstance := cache.NewCacheWithClient(client.Interface)
 	if err := cacheInstance.Start(); err != nil {
 		klog.Errorf("Failed to start cache: %v", err)
 		return err

--- a/pkg/utils/client.go
+++ b/pkg/utils/client.go
@@ -34,12 +34,21 @@ type Client struct {
 	config *rest.Config
 }
 
-// NewClient creates a new Kubernetes client with the given options.
+// NewClient creates a new Kubernetes client with client-go default rate limits.
 func NewClient() (*Client, error) {
+	return NewClientWithRateLimit(0, 0)
+}
+
+// NewClientWithRateLimit creates a new Kubernetes client with the given QPS
+// and burst. Zero values keep the client-go defaults (QPS 5, burst 10).
+// A negative QPS disables client-side rate limiting entirely.
+func NewClientWithRateLimit(qps float32, burst int) (*Client, error) {
 	restConfig, err := loadKubeConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
 	}
+	restConfig.QPS = qps
+	restConfig.Burst = burst
 
 	clientset, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {

--- a/pkg/utils/client_test.go
+++ b/pkg/utils/client_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 The HAMi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const fakeKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: fake
+  cluster:
+    server: https://127.0.0.1:6443
+contexts:
+- name: fake
+  context:
+    cluster: fake
+    user: fake
+current-context: fake
+users:
+- name: fake
+  user: {}
+`
+
+func TestNewClientWithRateLimitAppliesQPSAndBurst(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	if err := os.WriteFile(path, []byte(fakeKubeconfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("KUBECONFIG", path)
+
+	client, err := NewClientWithRateLimit(100, 150)
+	if err != nil {
+		t.Fatalf("NewClientWithRateLimit failed: %v", err)
+	}
+	if client.config.QPS != 100 || client.config.Burst != 150 {
+		t.Errorf("got QPS=%v Burst=%v, want 100 and 150", client.config.QPS, client.config.Burst)
+	}
+}


### PR DESCRIPTION
The monitor registered and validated `--kube-api-qps` and `--kube-api-burst` but never passed them to any client, so setting them did nothing. Add `utils.NewClientWithRateLimit` and use it in the monitor so the values reach the rest.Config. `utils.NewClient` keeps the client-go defaults.