### PR TITLE
chore: wire version subcommand, remove dead config helpers

### DIFF
--- a/cmd/monitor/app/monitor.go
+++ b/cmd/monitor/app/monitor.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Project-HAMi/HAMi-DRA/pkg/cache"
 	"github.com/Project-HAMi/HAMi-DRA/pkg/metrics"
 	"github.com/Project-HAMi/HAMi-DRA/pkg/version"
+	"github.com/Project-HAMi/HAMi-DRA/pkg/version/sharedcommand"
 )
 
 // NewMonitorCommand creates a *cobra.Command object with default parameters
@@ -83,6 +84,8 @@ and exposes them via Prometheus metrics endpoint.`,
 			return nil
 		},
 	}
+
+	cmd.AddCommand(sharedcommand.NewCmdVersion("monitor"))
 
 	cmd.Flags().AddFlagSet(genericFlagSet)
 	cmd.Flags().AddFlagSet(logsFlagSet)

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -41,6 +41,7 @@ import (
 	"github.com/Project-HAMi/HAMi-DRA/pkg/config"
 	"github.com/Project-HAMi/HAMi-DRA/pkg/featuregates"
 	"github.com/Project-HAMi/HAMi-DRA/pkg/version"
+	"github.com/Project-HAMi/HAMi-DRA/pkg/version/sharedcommand"
 	"github.com/Project-HAMi/HAMi-DRA/pkg/webhook/dra"
 	"github.com/Project-HAMi/HAMi-DRA/pkg/webhook/volcano"
 )
@@ -95,6 +96,8 @@ Kubernetes resources.`,
 			return nil
 		},
 	}
+
+	cmd.AddCommand(sharedcommand.NewCmdVersion("webhook"))
 
 	cmd.Flags().AddFlagSet(genericFlagSet)
 	cmd.Flags().AddFlagSet(logsFlagSet)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -201,16 +201,3 @@ func Unmarshal(data []byte) (*Config, error) {
 	}
 	return &config, nil
 }
-
-// UnmarshalNvidia is kept for callers that only need the NVIDIA section.
-func UnmarshalNvidia(data []byte) (*NvidiaConfig, error) {
-	cfg, err := Unmarshal(data)
-	if err != nil {
-		return nil, err
-	}
-	return &cfg.Nvidia, nil
-}
-
-func Marshal(nvidiaConfig *NvidiaConfig) ([]byte, error) {
-	return yaml.Marshal(nvidiaConfig)
-}


### PR DESCRIPTION
`sharedcommand.NewCmdVersion` existed but no binary used it. Add a `version` subcommand to the webhook and monitor commands.

Remove `config.UnmarshalNvidia` and `config.Marshal`. Nothing calls them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added version subcommands to the `monitor` and `webhook` commands, making it easier to check CLI version information.

* **Chores**
  * Removed a pair of configuration helper commands from the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->