### PR TITLE
docs: fix k8s-dcu-dra-driver link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then [use the same as hami](https://project-hami.io/zh/docs/userguide/nvidia-dev
 
 ### Hygon DCU
 
-For clusters running Hygon DCU with [k8s-dcu-dra-driver](https://github.com/Project-HAMi/k8s-dcu-dra-driver), see [docs/hygon-dcu.md](./docs/hygon-dcu.md).
+For clusters running Hygon DCU with [k8s-dcu-dra-driver](https://github.com/HYGON-AI/k8s-dcu-dra-driver), see [docs/hygon-dcu.md](./docs/hygon-dcu.md).
 
 ## Configuration
 


### PR DESCRIPTION
The README linked k8s-dcu-dra-driver as `Project-HAMi/k8s-dcu-dra-driver`, which returns 404. The repo lives under `HYGON-AI`, and `docs/hygon-dcu.md` already links there. Fix the org in the link.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the DCU installation guide to point to the correct GitHub repository for the driver.
  * Clarified the repository owner information so the setup instructions match the current project location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->