### PR TITLE
fix(webhook): clean up created templates when a volcano job fails midway

### DIFF
--- a/pkg/webhook/volcano/mutating.go
+++ b/pkg/webhook/volcano/mutating.go
@@ -62,6 +62,7 @@ func (a *MutatingAdmission) Handle(ctx context.Context, req admission.Request) a
 		task := &job.Spec.Tasks[i]
 		rctNames, err := a.handleTask(ctx, task, job)
 		if err != nil {
+			a.deleteResourceClaimTemplates(ctx, job.Namespace, append(rctNameList, rctNames...))
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
 		for _, rctName := range rctNames {
@@ -87,20 +88,25 @@ func (a *MutatingAdmission) Handle(ctx context.Context, req admission.Request) a
 
 	marshaledBytes, err := json.Marshal(job)
 	if err != nil {
-		for _, rctName := range rctNameList {
-			deletionErr := a.Client.Delete(ctx, &resourceapi.ResourceClaimTemplate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      rctName,
-					Namespace: job.Namespace,
-				},
-			})
-			if deletionErr != nil {
-				klog.V(5).Infof("Failed to delete ResourceClaimTemplate(%s/%s) for request: %s after an error occurs", job.Namespace, rctName, req.Operation)
-			}
-		}
+		a.deleteResourceClaimTemplates(ctx, job.Namespace, rctNameList)
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledBytes)
+}
+
+// deleteResourceClaimTemplates removes templates created earlier in the same
+// request after a later step fails.
+func (a *MutatingAdmission) deleteResourceClaimTemplates(ctx context.Context, namespace string, names []string) {
+	for _, name := range names {
+		if deletionErr := a.Client.Delete(ctx, &resourceapi.ResourceClaimTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}); deletionErr != nil {
+			klog.Errorf("Failed to delete ResourceClaimTemplate(%s/%s), it may need manual cleanup: %v", namespace, name, deletionErr)
+		}
+	}
 }
 
 // handleTask processes every container in the task and returns the names of
@@ -111,7 +117,8 @@ func (a *MutatingAdmission) handleTask(ctx context.Context, task *vcv1alpha1.Tas
 		container := &task.Template.Spec.Containers[i]
 		rctName, err := a.handleContainerTemplate(ctx, container, job.Namespace, task.Name)
 		if err != nil {
-			return nil, err
+			// Return the names created so far so the caller can clean them up.
+			return rctNames, err
 		}
 		if rctName != "" {
 			rctNames = append(rctNames, rctName)

--- a/pkg/webhook/volcano/mutating_test.go
+++ b/pkg/webhook/volcano/mutating_test.go
@@ -23,10 +23,13 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	vcv1alpha1 "volcano.sh/apis/pkg/apis/batch/v1alpha1"
@@ -202,6 +205,66 @@ func TestHandleTaskProcessesAllContainers(t *testing.T) {
 		require.Len(t, container.Resources.Claims, 1, "container %s should reference a claim", container.Name)
 	}
 	assert.Empty(t, task.Template.Spec.Containers[1].Resources.Claims, "cpu-only container should be untouched")
+}
+
+func TestHandleCleansUpTemplatesOnPartialFailure(t *testing.T) {
+	sch := runtime.NewScheme()
+	require.NoError(t, scheme.AddToScheme(sch))
+	require.NoError(t, vcv1alpha1.AddToScheme(sch))
+
+	// A template with the second container's name already exists, so its
+	// Create fails after the first container's template was created.
+	existing := &resourceapi.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-leak-task-gpu-two", Namespace: "default"},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(existing).Build()
+
+	mutating := &MutatingAdmission{
+		Decoder: admission.NewDecoder(sch),
+		Client:  fakeClient,
+		DeviceConfig: &config.DRADeviceConfig{
+			ResourceCountName: "nvidia.com/gpu",
+			RequestName:       "gpu",
+		},
+	}
+
+	gpuResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+		},
+	}
+	job := &vcv1alpha1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "leak", Namespace: "default"},
+		Spec: vcv1alpha1.JobSpec{
+			Tasks: []vcv1alpha1.TaskSpec{{
+				Name: "leak-task",
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "gpu-one", Resources: *gpuResources.DeepCopy()},
+							{Name: "gpu-two", Resources: *gpuResources.DeepCopy()},
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	jobRaw, err := json.Marshal(job)
+	require.NoError(t, err)
+	resp := mutating.Handle(context.Background(), admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Namespace: "default",
+			Operation: admissionv1.Create,
+			Object:    runtime.RawExtension{Raw: jobRaw},
+		},
+	})
+	require.False(t, resp.Allowed, "request should fail when a template cannot be created")
+
+	err = fakeClient.Get(context.Background(),
+		client.ObjectKey{Namespace: "default", Name: "default-leak-task-gpu-one"},
+		&resourceapi.ResourceClaimTemplate{})
+	assert.True(t, apierrors.IsNotFound(err), "template created before the failure should be deleted, got: %v", err)
 }
 
 func TestBuildResourceClaimTemplateUsesConfiguredDriver(t *testing.T) {


### PR DESCRIPTION
When creating a ResourceClaimTemplate failed for a later container, the volcano webhook returned 500 without deleting the templates it had already created for earlier containers and tasks. Those templates have no owner reference, and since their names are deterministic, resubmitting the same job then fails with AlreadyExists until the stale template is deleted by hand.

-handleTask now returns the names created so far on error
-Handle deletes them, plus the templates from earlier tasks, before returning the error
-The inline deletion loop moved to a small deleteResourceClaimTemplates helper used by both error paths

The DRA pod path already cleans up this way since #46; this brings the volcano path to parity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the mutating webhook’s reliability by automatically cleaning up any resource claim templates created during the same admission request if a later step fails.
  * Prevents orphaned templates when admission responses end in an error.
* **Tests**
  * Added a new test to verify templates are deleted after partial failure during per-container template creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->