### PR TITLE
Support fake DCU & fix precommit check license hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,10 +3,20 @@
 # Pre-commit hook to check license headers
 # To install: cp .githooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
 
+GO_LICENSE_FILES=()
+while IFS= read -r -d '' file; do
+    GO_LICENSE_FILES+=("$file")
+done < <(find . -name "*.go" -not -path "./vendor/*" -not -path "./.git/*" -not -path "./bin/*" -print0)
+
+if [ ${#GO_LICENSE_FILES[@]} -eq 0 ]; then
+    echo "✓ License headers check passed"
+    exit 0
+fi
+
 # Check if addlicense is available
 if command -v addlicense >/dev/null 2>&1; then
     # Check license headers
-    if ! addlicense -c "The HAMi Authors" -l apache -y 2025 -s -f .license-header.txt -check . 2>/dev/null; then
+    if ! addlicense -c "The HAMi Authors" -l apache -y 2026 -s -check "${GO_LICENSE_FILES[@]}" 2>/dev/null; then
         echo "❌ Some files are missing license headers!"
         echo "Run 'make license' to add license headers automatically."
         exit 1
@@ -14,12 +24,12 @@ if command -v addlicense >/dev/null 2>&1; then
 else
     # Fallback: simple check for license header
     missing_license=false
-    while IFS= read -r file; do
-        if ! head -n 20 "$file" | grep -q "Copyright 2025.*The HAMi Authors"; then
+    for file in "${GO_LICENSE_FILES[@]}"; do
+        if ! head -n 20 "$file" | grep -q "Copyright 20[0-9][0-9].*The HAMi Authors"; then
             echo "❌ Missing license header: $file"
             missing_license=true
         fi
-    done < <(find . -name "*.go" -not -path "./vendor/*" -not -path "./.git/*" -not -path "./bin/*")
+    done
     
     if [ "$missing_license" = true ]; then
         echo "Run 'make license' to add license headers automatically."
@@ -27,6 +37,4 @@ else
     fi
 fi
 
-echo "✓ License headers check passed"
 exit 0
-

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ BUILD_ARCH ?= linux/$(GOARCH)
 GOTOOLCHAIN ?= go1.26.6+auto
 GOLANGCI_LINT_VERSION ?= v2.5.0
 GOLANGCI_LINT_ARGS ?= --timeout=5m
+GO_LICENSE_FILES := $(shell find . -name "*.go" -not -path "./vendor/*" -not -path "./.git/*" -not -path "./bin/*")
 
 export GOTOOLCHAIN
 
@@ -144,18 +145,18 @@ cert:
 license:
 	@if command -v addlicense >/dev/null 2>&1; then \
 		echo "Using addlicense tool..."; \
-		addlicense -c "The HAMi Authors" -l apache -y 2026 -s -f .license-header.txt .; \
+		addlicense -c "The HAMi Authors" -l apache -y 2026 -s $(GO_LICENSE_FILES); \
 	else \
 		echo "addlicense not found, using script..."; \
-		echo "To install addlicense: ./scripts/install-addlicense.sh"; \
+		echo "To install addlicense: go install github.com/google/addlicense@latest"; \
 		./scripts/add-license.sh; \
 	fi
 
 # Check license headers (dry-run with addlicense)
 license-check:
 	@if command -v addlicense >/dev/null 2>&1; then \
-		addlicense -c "The HAMi Authors" -l apache -y 2026 -s -f .license-header.txt -check .; \
+		addlicense -c "The HAMi Authors" -l apache -y 2026 -s -check $(GO_LICENSE_FILES); \
 	else \
-		echo "addlicense not found. Install it with: ./scripts/install-addlicense.sh"; \
+		echo "addlicense not found. Install it with: go install github.com/google/addlicense@latest"; \
 		exit 1; \
 	fi

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then [use the same as hami](https://project-hami.io/zh/docs/userguide/nvidia-dev
 
 ### Hygon DCU
 
-For clusters running Hygon DCU with [k8s-dcu-dra-driver](https://github.com/HYGON-AI/k8s-dcu-dra-driver), see [docs/hygon-dcu.md](./docs/hygon-dcu.md).
+For clusters running Hygon DCU with [k8s-hcu-dra-driver](https://github.com/HYGON-AI/k8s-hcu-dra-driver), see [docs/hygon-dcu.md](./docs/hygon-dcu.md).
 
 ## Configuration
 

--- a/charts/hami-dra/Chart.yaml
+++ b/charts/hami-dra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hami-dra/templates/_helpers.tpl
+++ b/charts/hami-dra/templates/_helpers.tpl
@@ -37,6 +37,54 @@
 {{- end -}}
 
 {{- define "hami.dra.driver.fake.defaultConfig" -}}
+{{- if eq (include "hami.dra.driver.fake.profile" .) "hygon" -}}
+{{ include "hami.dra.driver.fake.defaultHygonConfig" . }}
+{{- else -}}
+{{ include "hami.dra.driver.fake.defaultNvidiaConfig" . }}
+{{- end -}}
+{{- end -}}
+
+{{- define "hami.dra.driver.fake.profile" -}}
+{{- $profile := .Values.drivers.fake.profile | default "nvidia" -}}
+{{- if and (ne $profile "nvidia") (ne $profile "hygon") -}}
+{{- fail (printf "drivers.fake.profile must be \"nvidia\" or \"hygon\", got %q" $profile) -}}
+{{- end -}}
+{{- $profile -}}
+{{- end -}}
+
+{{- define "hami.dra.driver.fake.deviceClassName" -}}
+{{- if eq (include "hami.dra.driver.fake.profile" .) "hygon" -}}
+{{- if or (not .Values.drivers.fake.deviceClassName) (eq .Values.drivers.fake.deviceClassName "fake-gpu.project-hami.io") -}}
+{{- .Values.dcuDeviceClassName -}}
+{{- else -}}
+{{- .Values.drivers.fake.deviceClassName -}}
+{{- end -}}
+{{- else -}}
+{{- .Values.drivers.fake.deviceClassName | default "fake-gpu.project-hami.io" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "hami.dra.driver.fake.driverName" -}}
+{{- if eq (include "hami.dra.driver.fake.profile" .) "hygon" -}}
+{{- if or (not .Values.drivers.fake.driverName) (eq .Values.drivers.fake.driverName "fake.dra.hami.io") -}}
+{{- .Values.dcuDraDriverName -}}
+{{- else -}}
+{{- .Values.drivers.fake.driverName -}}
+{{- end -}}
+{{- else -}}
+{{- .Values.drivers.fake.driverName | default "fake.dra.hami.io" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "hami.dra.driver.fake.deviceType" -}}
+{{- if eq (include "hami.dra.driver.fake.profile" .) "hygon" -}}
+{{- "dcu" -}}
+{{- else -}}
+{{- "hami-gpu" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "hami.dra.driver.fake.defaultNvidiaConfig" -}}
 groups:
   - name: default-a100
     devices:
@@ -88,6 +136,58 @@ groups:
 {{- end }}
 {{- end -}}
 
+{{- define "hami.dra.driver.fake.defaultHygonConfig" -}}
+{{/*
+  Fake DCU devices aligned with dra.hygon.com ResourceSlice from
+  HYGON-AI/k8s-hcu-dra-driver (K100_AI):
+  attributes: architecture/brand/productName/type/uuid
+  capacity: cores=120, memory=65520Mi, slices=4 (max 4 vHCU per card)
+*/}}
+groups:
+  - name: default-dcu
+    devices:
+{{- range $index := until 8 }}
+      - name: dcu-0000-00-{{ printf "%02d" $index }}-0
+        allowMultipleAllocations: true
+        attributes:
+          architecture:
+            string: ""
+          brand:
+            string: ""
+          productName:
+            string: K100_AI
+          type:
+            string: dcu
+          uuid:
+            string: {{ printf "TPXS3000021%05d" $index }}
+        capacity:
+          cores:
+            value: "120"
+            requestPolicy:
+              default: "120"
+              validRange:
+                max: "120"
+                min: "0"
+                step: "1"
+          memory:
+            value: 65520Mi
+            requestPolicy:
+              default: 65520Mi
+              validRange:
+                max: 65520Mi
+                min: "0"
+                step: 1Mi
+          slices:
+            value: "4"
+            requestPolicy:
+              default: "1"
+              validRange:
+                max: "4"
+                min: "1"
+                step: "1"
+{{- end }}
+{{- end -}}
+
 {{- define "hami.dra.dcu.deviceClassName" -}}
 {{- if .Values.drivers.dcu.deviceClassName -}}
 {{- .Values.drivers.dcu.deviceClassName -}}
@@ -105,20 +205,20 @@ groups:
 {{- end -}}
 
 {{- define "hami.dra.webhook.deviceClassName" -}}
-{{- if eq (include "hami.dra.webhook.deviceVendor" .) "hygon" -}}
+{{- if and .Values.drivers.fake.enabled (not .Values.drivers.nvidia.enabled) -}}
+{{- include "hami.dra.driver.fake.deviceClassName" . -}}
+{{- else if eq (include "hami.dra.webhook.deviceVendor" .) "hygon" -}}
 {{- include "hami.dra.dcu.deviceClassName" . -}}
-{{- else if and .Values.drivers.fake.enabled (not .Values.drivers.nvidia.enabled) -}}
-{{- .Values.drivers.fake.deviceClassName -}}
 {{- else -}}
 {{- "hami-core-gpu.project-hami.io" -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "hami.dra.webhook.driverName" -}}
-{{- if eq (include "hami.dra.webhook.deviceVendor" .) "hygon" -}}
+{{- if and .Values.drivers.fake.enabled (not .Values.drivers.nvidia.enabled) -}}
+{{- include "hami.dra.driver.fake.driverName" . -}}
+{{- else if eq (include "hami.dra.webhook.deviceVendor" .) "hygon" -}}
 {{- include "hami.dra.dcu.driverName" . -}}
-{{- else if and .Values.drivers.fake.enabled (not .Values.drivers.nvidia.enabled) -}}
-{{- .Values.drivers.fake.driverName -}}
 {{- else -}}
 {{- "hami-core-gpu.project-hami.io" -}}
 {{- end -}}

--- a/charts/hami-dra/templates/hami-dra-driver/deviceclass.yaml
+++ b/charts/hami-dra/templates/hami-dra-driver/deviceclass.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.drivers.fake.enabled .Values.drivers.dcu.enabled (eq (include "hami.dra.driver.fake.profile" .) "hygon") }}
+{{- fail "drivers.fake.enabled (profile=hygon) and drivers.dcu.enabled cannot both be true: both would create DeviceClass dra.hygon.com (or the same custom name). Use fake alone for testing, or the real DCU driver alone." -}}
+{{- end }}
 {{- if .Values.drivers.nvidia.enabled }}
 apiVersion: resource.k8s.io/v1
 kind: DeviceClass
@@ -16,10 +19,10 @@ spec:
 apiVersion: resource.k8s.io/v1
 kind: DeviceClass
 metadata:
-  name: {{ .Values.drivers.fake.deviceClassName }}
+  name: {{ include "hami.dra.driver.fake.deviceClassName" . }}
 spec:
   selectors:
   - cel:
       expression: |-
-        device.driver == "{{ .Values.drivers.fake.driverName }}" && device.attributes["{{ .Values.drivers.fake.driverName }}"].type == "hami-gpu"
+        device.driver == "{{ include "hami.dra.driver.fake.driverName" . }}" && device.attributes["{{ include "hami.dra.driver.fake.driverName" . }}"].type == "{{ include "hami.dra.driver.fake.deviceType" . }}"
 {{- end }}

--- a/charts/hami-dra/templates/hami-dra-driver/fake-driver-daemonset.yaml
+++ b/charts/hami-dra/templates/hami-dra-driver/fake-driver-daemonset.yaml
@@ -35,7 +35,7 @@ spec:
         - /bin/fake-driver
         args:
         - --node-name=$(NODE_NAME)
-        - --driver-name={{ .Values.drivers.fake.driverName }}
+        - --driver-name={{ include "hami.dra.driver.fake.driverName" . }}
         - --configmap-name={{ include "hami.dra.driver.fake.configMapName" . }}
         - --configmap-namespace={{ .Release.Namespace }}
         - --configmap-key={{ .Values.drivers.fake.configMap.key }}

--- a/charts/hami-dra/values.yaml
+++ b/charts/hami-dra/values.yaml
@@ -197,6 +197,11 @@ drivers:
       pullSecrets: []
   fake:
     enabled: false
+    # Built-in fake device profile. Supported values: nvidia, hygon.
+    # hygon mirrors k8s-hcu-dra-driver ResourceSlice (K100_AI, slices=4) for DCU DRA testing.
+    # Unknown values fail chart rendering. Do not enable with drivers.dcu.enabled
+    # when profile=hygon — both target DeviceClass dra.hygon.com.
+    profile: nvidia
     deviceClassName: fake-gpu.project-hami.io
     image:
       registry: ghcr.io
@@ -225,10 +230,12 @@ drivers:
       name: ""
       key: config.yaml
       # Optional inline override. When empty, the chart renders a built-in default:
-      # 8 fake NVIDIA A100-SXM4-80GB devices on every node.
+      # 8 fake devices on every node using drivers.fake.profile.
       inlineData: ""
   dcu:
-    # Reserved; no DCU driver template in this chart. Deploy k8s-dcu-dra-driver separately.
+    # Reserved; no DCU driver template in this chart. Deploy k8s-hcu-dra-driver separately.
+    # Keep false when drivers.fake.enabled=true with profile=hygon to avoid a
+    # duplicate DeviceClass name (dra.hygon.com).
     enabled: false
     # Override DeviceClass/driver name in webhook config only.
     # Leave empty to use dcuDeviceClassName / dcuDraDriverName.

--- a/docs/fake-dra-driver.md
+++ b/docs/fake-dra-driver.md
@@ -132,8 +132,41 @@ Important values:
 1. `drivers.fake.image.*`: fake plugin image settings.
 2. `drivers.fake.driverName`: DRA driver name.
 3. `drivers.fake.deviceClassName`: defaults to `fake-gpu.project-hami.io`.
-4. `drivers.fake.configMap.existingName`: use an existing `ConfigMap`; when set, the chart does not create one.
-5. `drivers.fake.configMap.name`: optional custom name for the chart-managed `ConfigMap`.
-6. `drivers.fake.configMap.key`: defaults to `config.yaml`.
-7. By default, the template renders a built-in `ConfigMap` that creates eight `A100-SXM4-80GB` fake devices on every node.
-8. If you need to override the default content, use `drivers.fake.configMap.inlineData`.
+4. `drivers.fake.profile`: built-in fake device profile, either `nvidia` or `hygon`.
+5. `drivers.fake.configMap.existingName`: use an existing `ConfigMap`; when set, the chart does not create one.
+6. `drivers.fake.configMap.name`: optional custom name for the chart-managed `ConfigMap`.
+7. `drivers.fake.configMap.key`: defaults to `config.yaml`.
+8. By default, the template renders a built-in `ConfigMap` that creates eight fake devices on every node.
+9. If you need to override the default content, use `drivers.fake.configMap.inlineData`.
+
+### Hygon DCU fake driver
+
+The `hygon` profile mirrors a real `dra.hygon.com` ResourceSlice from
+[`HYGON-AI/k8s-hcu-dra-driver`](https://github.com/HYGON-AI/k8s-hcu-dra-driver)
+(K100_AI): `type: dcu`, `productName: K100_AI`, `cores=120`, `memory=65520Mi`,
+and `slices=4` (one physical card can be split into at most 4 vHCU;
+`requestPolicy.default` is `1`). Driver/DeviceClass naming stays `dra.hygon.com`.
+
+```bash
+helm upgrade --install hami-dra ./charts/hami-dra \
+  --set deviceVendor=hygon \
+  --set drivers.nvidia.enabled=false \
+  --set drivers.fake.enabled=true \
+  --set drivers.fake.profile=hygon
+```
+
+With the default fake driver names still set in `values.yaml`, `profile=hygon` automatically renders:
+
+1. `DeviceClass` name: `dra.hygon.com`
+2. fake driver `--driver-name`: `dra.hygon.com`
+3. selector type: `device.attributes["dra.hygon.com"].type == "dcu"`
+
+Set `drivers.fake.deviceClassName` or `drivers.fake.driverName` explicitly if you need different names.
+
+Do **not** enable `drivers.fake` with `profile=hygon` together with:
+
+1. `drivers.dcu.enabled=true` in this chart, or
+2. a live `k8s-hcu-dra-driver` that already owns `DeviceClass` `dra.hygon.com`
+
+Either setup alone is fine; enabling both creates a duplicate DeviceClass name conflict.
+Unknown `drivers.fake.profile` values (for example a typo like `hygonn`) fail chart rendering instead of silently falling back to `nvidia`.

--- a/docs/hygon-dcu.md
+++ b/docs/hygon-dcu.md
@@ -1,13 +1,13 @@
 # Hygon DCU
 
-Deploy HAMi-DRA webhook for Hygon DCU clusters that already run [k8s-dcu-dra-driver](https://github.com/HYGON-AI/k8s-dcu-dra-driver).
+Deploy HAMi-DRA webhook for Hygon DCU clusters that already run [k8s-hcu-dra-driver](https://github.com/HYGON-AI/k8s-hcu-dra-driver).
 
-This chart deploys only the mutating/validating webhook and TLS certificates. The DCU DRA driver and `DeviceClass` (`dra.hygon.com`) must be deployed separately via k8s-dcu-dra-driver.
+This chart deploys only the mutating/validating webhook and TLS certificates. The DCU DRA driver and `DeviceClass` (`dra.hygon.com`) must be deployed separately via k8s-hcu-dra-driver.
 
 ## Prerequisites
 
 1. Kubernetes with DRA enabled (same requirements as the main chart).
-2. [k8s-dcu-dra-driver](https://github.com/HYGON-AI/k8s-dcu-dra-driver) deployed; `DeviceClass` `dra.hygon.com` must exist.
+2. [k8s-hcu-dra-driver](https://github.com/HYGON-AI/k8s-hcu-dra-driver) deployed; `DeviceClass` `dra.hygon.com` must exist.
 3. [cert-manager](https://cert-manager.io/docs/installation/) installed.
 4. `hami-dra-webhook` image built and reachable from all nodes (override `webhook.image.*` if not using the default registry).
 
@@ -90,4 +90,8 @@ For whole-card requests only (`hygon.com/dcunum` without `dcumem` / `dcucores`),
 | cert-manager resources | Yes | Yes |
 | NVIDIA DRA driver DaemonSet | No | Yes |
 | hami-dra-monitor | No | Yes |
-| DCU DRA driver | External (k8s-dcu-dra-driver) | N/A |
+| DCU DRA driver | External (k8s-hcu-dra-driver) | N/A |
+
+## Testing without DCU hardware
+
+To publish fake `dra.hygon.com` ResourceSlices (including `capacity.slices=4`) instead of installing the real driver, see [fake-dra-driver.md](./fake-dra-driver.md). Do not enable `drivers.fake.profile=hygon` together with a live k8s-hcu-dra-driver: both would claim `DeviceClass` `dra.hygon.com`.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -95,7 +95,7 @@ type Config struct {
 	Hygon  HygonConfig  `yaml:"hygon"`
 }
 
-// HygonConfig holds DCU DRA settings for k8s-dcu-dra-driver (dra.hygon.com).
+// HygonConfig holds DCU DRA settings for k8s-hcu-dra-driver (dra.hygon.com).
 type HygonConfig struct {
 	ResourceCountName  string `yaml:"resourceCountName"`
 	ResourceMemoryName string `yaml:"resourceMemoryName"`

--- a/scripts/add-license.sh
+++ b/scripts/add-license.sh
@@ -27,6 +27,11 @@ remove_old_license() {
     
     while IFS= read -r line || [ -n "$line" ]; do
         if [[ "$line" =~ ^/\* ]]; then
+            # Single-line block comments (/* ... */) close on the same line.
+            if [[ "$line" =~ \*/ ]]; then
+                skip_until_empty=true
+                continue
+            fi
             in_comment=true
             skip_until_empty=true
             continue
@@ -50,6 +55,37 @@ remove_old_license() {
     mv "$temp_file" "$file"
 }
 
+# Function to check whether the leading block comment is a license header
+has_leading_license_block() {
+    local file=$1
+    local temp_file=$(mktemp)
+    local in_comment=false
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        if [[ "$in_comment" == false && "$line" =~ ^/\* ]]; then
+            in_comment=true
+        fi
+
+        if [[ "$in_comment" == true ]]; then
+            echo "$line" >> "$temp_file"
+            if [[ "$line" =~ \*/ ]]; then
+                break
+            fi
+            continue
+        fi
+
+        break
+    done < "$file"
+
+    if grep -Eq "Copyright|Licensed under the Apache License|SPDX-License-Identifier" "$temp_file"; then
+        rm -f "$temp_file"
+        return 0
+    fi
+
+    rm -f "$temp_file"
+    return 1
+}
+
 # Find all Go files excluding vendor and .git directories
 find . -name "*.go" -not -path "./vendor/*" -not -path "./.git/*" -not -path "./bin/*" | while read -r file; do
     if has_correct_license "$file"; then
@@ -57,8 +93,8 @@ find . -name "*.go" -not -path "./vendor/*" -not -path "./.git/*" -not -path "./
         continue
     fi
     
-    # Remove old license if exists
-    if head -n 1 "$file" | grep -q "^/\*"; then
+    # Remove an old license header if one exists. Keep ordinary package docs.
+    if head -n 1 "$file" | grep -q "^/\*" && has_leading_license_block "$file"; then
         remove_old_license "$file"
     fi
     

--- a/scripts/add-license.sh
+++ b/scripts/add-license.sh
@@ -29,7 +29,7 @@ remove_old_license() {
         if [[ "$line" =~ ^/\* ]]; then
             # Single-line block comments (/* ... */) close on the same line.
             if [[ "$line" =~ \*/ ]]; then
-                skip_until_empty=true
+                skip_until_empty=false
                 continue
             fi
             in_comment=true


### PR DESCRIPTION
Support fake DCU so we can check if the resourceClaim generated by HAMi DRA can be used by DCU-dra-driver without dcu device.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added NVIDIA and Hygon profiles for the fake DRA driver.
  - Added profile-specific device classes, driver names, device types, and default configurations.
  - Added support for simulating eight Hygon DCU devices per node without physical hardware.
  - Chart rendering now prevents conflicting fake Hygon and live DCU driver configurations.

- **Documentation**
  - Updated Helm integration, Hygon DCU setup, testing guidance, and driver references.
  - Clarified fake-driver configuration and profile-specific resource selectors.

- **Bug Fixes**
  - License-header tooling now preserves ordinary package documentation comments and checks only applicable Go files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->