### PR TITLE
fix(chart): apply webhook.resources to webhook deployment

### DIFF
--- a/charts/hami-dra/Chart.yaml
+++ b/charts/hami-dra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6
+version: 0.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hami-dra/templates/webhook/webhook-deployment.yaml
+++ b/charts/hami-dra/templates/webhook/webhook-deployment.yaml
@@ -42,6 +42,10 @@ spec:
             - containerPort: 8000
               name: health
               protocol: TCP
+          {{- if .Values.webhook.resources }}
+          resources:
+            {{- toYaml .Values.webhook.resources | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: device-config
               mountPath: /device-config.yaml


### PR DESCRIPTION
webhook.resources was defined in values.yaml but the deployment template never used it, so limits and requests were silently ignored. Monitor deployment already does this correctly, webhook did not.