### PR TITLE
chore(chart): remove unused clusterIssuerName value

### DIFF
--- a/charts/hami-dra/Chart.yaml
+++ b/charts/hami-dra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.10
+version: 0.2.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hami-dra/values.yaml
+++ b/charts/hami-dra/values.yaml
@@ -152,8 +152,6 @@ certs:
     # In cert-manager >= v1.18.0, the default changed from "Never" to "Always"
     # Setting to "Never" avoids frequent certificate rotation for webhooks
     privateKeyRotationPolicy: "Never"
-    issuer:
-      clusterIssuerName: ""  # Required when type is "clusterIssuer"
 
 # DRA Drivers configuration
 drivers:


### PR DESCRIPTION
certs.certManager.issuer.clusterIssuerName was never read by any template, the chart always creates a hardcoded self-signed Issuer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Helm chart release version.
  * Removed the obsolete certificate issuer configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->