### PR TITLE
fix(webhook): add explicit failurePolicy and configurable replicas

### DIFF
--- a/charts/hami-dra/Chart.yaml
+++ b/charts/hami-dra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.10
+version: 0.2.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hami-dra/templates/webhook/mutatingwebhookconfiguration.yaml
+++ b/charts/hami-dra/templates/webhook/mutatingwebhookconfiguration.yaml
@@ -31,6 +31,7 @@ webhooks:
         scope: '*'
     sideEffects: None
     timeoutSeconds: 10
+    failurePolicy: {{ .Values.webhook.config.mutating.failurePolicy | default "Fail" }}
 {{- if .Values.webhook.config.scope.enabled }}
     namespaceSelector:
       matchExpressions:
@@ -61,6 +62,7 @@ webhooks:
         scope: '*'
     sideEffects: None
     timeoutSeconds: 10
+    failurePolicy: {{ .Values.webhook.config.volcano.failurePolicy | default "Fail" }}
 {{- if .Values.webhook.config.scope.enabled }}
     namespaceSelector:
       matchExpressions:

--- a/charts/hami-dra/templates/webhook/webhook-deployment.yaml
+++ b/charts/hami-dra/templates/webhook/webhook-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "hami-dra-webhook.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.webhook.replicas | default 1 }}
   selector:
     matchLabels:
       {{- include "hami-dra-webhook.selectorLabels" . | nindent 6 }}

--- a/charts/hami-dra/values.yaml
+++ b/charts/hami-dra/values.yaml
@@ -51,6 +51,7 @@ kunlunResourceVMemoryName: "kunlunxin.com/vxpu-memory"
 
 # Webhook deployment configuration
 webhook:
+  replicas: 1
   image:
     registry: ghcr.io
     repository: project-hami/hami-dra-webhook
@@ -82,6 +83,10 @@ webhook:
   config:
     mutating:
       enabled: true
+      # "Fail" or "Ignore". Set to "Ignore" to keep pod creation working if the
+      # webhook is unavailable, at the cost of pods possibly starting without
+      # their GPU ResourceClaims.
+      failurePolicy: Fail
     validating:
       enabled: true
     scope:
@@ -93,6 +98,8 @@ webhook:
         - kube-system
     volcano:
       enabled: true
+      # "Fail" or "Ignore", see webhook.config.mutating.failurePolicy.
+      failurePolicy: Fail
 
 # Monitor deployment configuration
 monitor:

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -32,6 +32,7 @@ import (
 	logsv1 "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -213,6 +214,15 @@ func Run(ctx context.Context, opts *options.Options) error {
 	validatingAdmissionVolcano.Decoder = decoder
 	validatingAdmissionVolcano.Client = hookManager.GetClient()
 	hookServer.Register("/validate-volcano", &webhook.Admission{Handler: validatingAdmissionVolcano})
+
+	if err := hookManager.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		klog.Errorf("Failed to add healthz check: %v", err)
+		return err
+	}
+	if err := hookManager.AddReadyzCheck("readyz", hookServer.StartedChecker()); err != nil {
+		klog.Errorf("Failed to add readyz check: %v", err)
+		return err
+	}
 
 	// blocks until the context is done.
 	if err := hookManager.Start(ctx); err != nil {


### PR DESCRIPTION
Mutating webhook had no failurePolicy (defaults to Fail) and a hardcoded single replica. If the one webhook pod goes down, all pod creation in the cluster can block.

Wire up healthz/readyz checks in the webhook binary too (controller-runtime does not register them by default, verified by running the built binary and curling both endpoints), so a future chart change can add liveness/readiness probes once a released image serves them.

Chart probes are not added in this PR: the published webhook image (v0.2.1) predates this code change, so a probe hitting /healthz on that image would 404 and fail CI's chart install test until a new image is released. Opening as a follow-up once a new image tag is available.