### PR TITLE
fix: run webhook and monitor as non-root

### DIFF
--- a/charts/hami-dra/Chart.yaml
+++ b/charts/hami-dra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.8
+version: 0.2.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hami-dra/templates/monitor/monitor-deployment.yaml
+++ b/charts/hami-dra/templates/monitor/monitor-deployment.yaml
@@ -22,6 +22,13 @@ spec:
         - name: monitor
           image: {{ include "hami.dra.monitor.image" . }}
           imagePullPolicy: {{ .Values.monitor.image.pullPolicy | default "IfNotPresent" }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           command:
             - /bin/monitor
             - --v={{ .Values.monitor.logLevel | default 2 }}

--- a/charts/hami-dra/templates/webhook/webhook-deployment.yaml
+++ b/charts/hami-dra/templates/webhook/webhook-deployment.yaml
@@ -21,6 +21,13 @@ spec:
         - name: webhook
           image: {{ include "hami.dra.webhook.image" . }}
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy | default "IfNotPresent" }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           command:
             - /bin/webhook
             - --v=5

--- a/docker/hami-dra-monitor/Dockerfile
+++ b/docker/hami-dra-monitor/Dockerfile
@@ -22,6 +22,8 @@ COPY pkg/ pkg/
 RUN go build -ldflags="-s -w" -a -o monitor cmd/monitor/main.go && echo "Building GOARCH of $GOARCH.."
 
 FROM  alpine:3.18
+RUN adduser -D -u 1000 monitor
 COPY --from=builder /workspace/monitor /bin/monitor
+USER monitor
 CMD ["/bin/monitor"]
 

--- a/docker/hami-dra-webhook/Dockerfile
+++ b/docker/hami-dra-webhook/Dockerfile
@@ -22,5 +22,7 @@ COPY pkg/ pkg/
 RUN go build -ldflags="-s -w" -a -o webhook cmd/webhook/main.go && echo "Building GOARCH of $GOARCH.."
 
 FROM  alpine:3.18
+RUN adduser -D -u 1000 webhook
 COPY --from=builder /workspace/webhook /bin/webhook
+USER webhook
 CMD ["/bin/webhook"]


### PR DESCRIPTION
- webhook and monitor deployments had no securityContext, containers ran as root
- add non-root user to both Dockerfiles, add securityContext (runAsNonRoot, fixed uid, no privilege escalation, all capabilities dropped) to both deployment templates
