### PR TITLE
fix: check scheme registration errors in webhook

### DIFF
--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -136,8 +136,14 @@ func Run(ctx context.Context, opts *options.Options) error {
 	}
 	// Create a new scheme and add default Kubernetes schemes
 	sch := runtime.NewScheme()
-	_ = scheme.AddToScheme(sch)
-	_ = vcv1alpha1.AddToScheme(sch)
+	if err := scheme.AddToScheme(sch); err != nil {
+		klog.Errorf("Failed to add default scheme: %v", err)
+		return err
+	}
+	if err := vcv1alpha1.AddToScheme(sch); err != nil {
+		klog.Errorf("Failed to add volcano scheme: %v", err)
+		return err
+	}
 
 	config, err := controllerruntime.GetConfig()
 	if err != nil {


### PR DESCRIPTION

- scheme.AddToScheme and vcv1alpha1.AddToScheme errors were discarded with `_ =`
- now return the error and log it, so a scheme registration failure fails startup clearly instead of showing up later as a decode error
