### PR TITLE
fix: scope down ResourceClaim RBAC verbs on webhook role

### DIFF
--- a/charts/hami-dra/Chart.yaml
+++ b/charts/hami-dra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.8
+version: 0.2.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hami-dra/templates/webhook/webhook-clusterrole.yaml
+++ b/charts/hami-dra/templates/webhook/webhook-clusterrole.yaml
@@ -11,4 +11,4 @@ rules:
   verbs: ["get", "list", "watch"]
 - apiGroups: ["resource.k8s.io"]
   resources: ["resourceclaims", "resourceclaimtemplates"]
-  verbs: ["*"]
+  verbs: ["create", "delete"]


### PR DESCRIPTION

- webhook ClusterRole had verbs: ["*"] on resourceclaims/resourceclaimtemplates
- code only calls Client.Create and Client.Delete on these types (checked pkg/webhook, no Get/List/Watch calls), scope verbs down to create/delete
- monitor already has its own separate ClusterRole with get/list/watch on resourceclaims, unaffected by this change
