### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+HAMi-DRA is a subproject of [HAMi](https://github.com/Project-HAMi/HAMi). See
+the [HAMi security policy](https://github.com/Project-HAMi/HAMi/blob/master/SECURITY.md)
+for the project's general security posture.
+
+## Supported Versions
+
+Only the latest released version of HAMi-DRA receives security fixes.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public issue for a security vulnerability. Report it
+privately through [GitHub Security Advisories](https://github.com/Project-HAMi/HAMi-DRA/security/advisories/new).
+
+Include a clear description, reproduction steps, and the potential impact.
+Response times may vary with weekends, holidays, and time zones, but
+maintainers aim to reply within 5 working days.
+
+## Third-Party Dependencies
+
+HAMi-DRA relies on third-party Go modules. Dependency vulnerabilities are
+monitored and patched via Dependabot and periodic `govulncheck` audits.


### PR DESCRIPTION
- Adds `SECURITY.md` describing how to privately report vulnerabilities (GitHub Security Advisories), matching the parent HAMi project's process.
- Closes the "Security policy: Disabled" gap in the repo's Security overview.

Related repo-settings toggles (secret scanning, push protection, private vulnerability reporting, Dependabot security updates, code scanning default setup) were already enabled directly via the GitHub API by the repo owner; no code change needed for those.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a security policy covering supported versions and the project’s relationship to HAMi.
  * Documented private vulnerability reporting, response timelines, and third-party dependency monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->