### PR TITLE
ci: add least-privilege permissions to test-and-lint workflow

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Tests


### PR DESCRIPTION
- Adds a top-level `permissions: contents: read` to `test-and-lint.yml`, closing 4 CodeQL alerts (`actions/missing-workflow-permissions`) flagged after enabling code scanning default setup.
- None of the jobs in this workflow (test, lint, helm-template, helm-chart-test) write to the repo, packages, or PRs, so read-only contents access is sufficient.
- `docker-publish.yml` and `helm-release.yml` already declare explicit permissions, no change needed there.