### PR TITLE
docs: add code of conduct, PR template and security insights metadata

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+**What type of PR is this?**
+
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind deprecation
+/kind design
+/kind documentation
+/kind failing-test
+/kind feature
+/kind flake
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+Fixes #
+
+**Special notes for your reviewer**:
+
+**Does this PR introduce a user-facing change?**:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# HAMi Community Code of Conduct
+
+Please refer to our [HAMi Community Code of Conduct](https://github.com/Project-HAMi/community/blob/main/CODE-OF-CONDUCT.md).

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,0 +1,119 @@
+header:
+  schema-version: 2.0.0
+  last-updated: '2026-08-04'
+  last-reviewed: '2026-08-04'
+  url: https://github.com/Project-HAMi/HAMi-DRA/blob/main/SECURITY-INSIGHTS.yml
+  comment: |
+    Security metadata for the HAMi-DRA project, following the OpenSSF
+    Security Insights specification.
+
+project:
+  name: HAMi-DRA
+  homepage: https://project-hami.io
+  documentation:
+    code-of-conduct: https://github.com/Project-HAMi/HAMi-DRA/blob/main/CODE_OF_CONDUCT.md
+  administrators:
+    - name: limengxuan
+      affiliation: dynamia.ai
+      email: mengxuan.li@dynamia.ai
+      primary: true
+    - name: Jifei Wang
+      affiliation: independent
+      email: poff2001@outlook.com
+      primary: false
+    - name: Calvin Chen
+      affiliation: independent
+      email: 120380290@qq.com
+      primary: false
+  repositories:
+    - name: HAMi-DRA
+      url: https://github.com/Project-HAMi/HAMi-DRA
+      comment: |
+        Kubernetes mutating webhook and monitor that convert GPU device
+        resource requests to Dynamic Resource Allocation (DRA)
+        ResourceClaims, subproject of HAMi.
+  vulnerability-reporting:
+    reports-accepted: true
+    bug-bounty-available: false
+    contact:
+      name: HAMi-DRA maintainers
+      primary: true
+    security-policy: https://github.com/Project-HAMi/HAMi-DRA/blob/main/SECURITY.md
+    comment: |
+      Report vulnerabilities privately via GitHub Security Advisories:
+      https://github.com/Project-HAMi/HAMi-DRA/security/advisories/new
+      See SECURITY.md for the full policy and response process.
+
+repository:
+  url: https://github.com/Project-HAMi/HAMi-DRA
+  status: active
+  accepts-change-request: true
+  accepts-automated-change-request: true
+  bug-fixes-only: false
+  no-third-party-packages: false
+  core-team:
+    - name: limengxuan
+      affiliation: dynamia.ai
+      email: mengxuan.li@dynamia.ai
+      primary: true
+    - name: Jifei Wang
+      affiliation: independent
+      email: poff2001@outlook.com
+      primary: false
+    - name: Calvin Chen
+      affiliation: independent
+      email: 120380290@qq.com
+      primary: false
+  documentation:
+    contributing-guide: https://github.com/Project-HAMi/HAMi-DRA/blob/main/CONTRIBUTING.md
+    security-policy: https://github.com/Project-HAMi/HAMi-DRA/blob/main/SECURITY.md
+    governance: https://github.com/Project-HAMi/community/blob/main/community-membership.md
+  license:
+    url: https://github.com/Project-HAMi/HAMi-DRA/blob/main/LICENSE
+    expression: Apache-2.0
+  security:
+    assessments:
+      self:
+        comment: |
+          Dependencies are monitored with Dependabot and scanned in CI
+          (CodeQL, govulncheck). Go toolchain and module updates are
+          applied promptly when vulnerabilities are published.
+    tools:
+      - name: Dependabot
+        type: SCA
+        version: latest
+        rulesets:
+          - built-in
+        integration:
+          adhoc: false
+          ci: true
+          release: false
+        results: {}
+        comment: |
+          Automated dependency update PRs for Go modules and GitHub Actions.
+      - name: CodeQL
+        type: SAST
+        version: latest
+        rulesets:
+          - built-in
+        integration:
+          adhoc: false
+          ci: true
+          release: false
+        results: {}
+        comment: |
+          Static analysis on pull requests via GitHub Actions.
+      - name: GitHub secret scanning
+        type: secret-scanning
+        version: latest
+        rulesets:
+          - built-in
+        integration:
+          adhoc: false
+          ci: true
+          release: false
+        results: {}
+        comment: |
+          GitHub native secret scanning with push protection, enabled
+          on the repository to detect supported secret patterns and
+          block them from being pushed.


### PR DESCRIPTION
- Adds `CODE_OF_CONDUCT.md` pointing to the shared HAMi community Code of Conduct, matching the pattern already used in CONTRIBUTING.md.
- Adds `.github/PULL_REQUEST_TEMPLATE.md`, same template used by the HAMi main repo.
- Adds `SECURITY-INSIGHTS.yml` (OpenSSF Security Insights spec) with maintainer contacts (sourced from OWNERS + public GitHub profile emails), license, and enabled security tooling (Dependabot, CodeQL, secret scanning).

Brings GitHub's community profile health from 50% to 100% and satisfies the "Generate YAML security file" prompt on LFX Insights