### PR TITLE
feat(chart): add PodDisruptionBudget for the webhook

### DIFF
--- a/charts/hami-dra/Chart.yaml
+++ b/charts/hami-dra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hami-dra/templates/webhook/webhook-pdb.yaml
+++ b/charts/hami-dra/templates/webhook/webhook-pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.webhook.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "hami.dra.webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hami-dra-webhook.labels" . | nindent 4 }}
+spec:
+  maxUnavailable: {{ .Values.webhook.pdb.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "hami-dra-webhook.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/hami-dra/values.yaml
+++ b/charts/hami-dra/values.yaml
@@ -78,6 +78,13 @@ webhook:
     requests:
       cpu: 100m
       memory: 128Mi
+  ## @param pdb PodDisruptionBudget for the webhook Deployment.
+  ## maxUnavailable is used instead of minAvailable so this stays safe even
+  ## with a single replica (minAvailable:1 at replicas:1 would block evictions
+  ## entirely and prevent node drains).
+  pdb:
+    enabled: true
+    maxUnavailable: 1
   ## @param nodeSelector controllerManager node labels for pod assignment
   # Webhook configuration
   config:


### PR DESCRIPTION
- Adds a PodDisruptionBudget for the webhook Deployment, gated behind `webhook.pdb.enabled` (default true).
- Uses `maxUnavailable: 1` rather than `minAvailable`, so it's safe at the current default replica count of 1: `minAvailable: 1` on a single replica would block eviction entirely (voluntary disruptions like node drains would never be allowed), while `maxUnavailable: 1` permits the sole pod to be evicted since 1 unavailable pod is within budget.
