### PR TITLE
ci: add OpenSSF Scorecard and image vulnerability scanning

### DIFF
--- a/.github/workflows/image-scanning.yaml
+++ b/.github/workflows/image-scanning.yaml
@@ -1,0 +1,60 @@
+name: Image Vulnerability Scan
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trivy-scan:
+    name: Trivy Scan (${{ matrix.component.name }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif
+    strategy:
+      matrix:
+        component:
+          - name: webhook
+            dockerfile: ./docker/hami-dra-webhook/Dockerfile
+          - name: monitor
+            dockerfile: ./docker/hami-dra-monitor/Dockerfile
+          - name: fake-driver
+            dockerfile: ./docker/hami-dra-fake-driver/Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
+
+      - name: Build image
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09
+        with:
+          context: .
+          file: ${{ matrix.component.dockerfile }}
+          push: false
+          load: true
+          tags: hami-dra-${{ matrix.component.name }}:scan
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: hami-dra-${{ matrix.component.name }}:scan
+          format: sarif
+          output: trivy-${{ matrix.component.name }}.sarif
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+          vuln-type: os,library
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+        with:
+          sarif_file: trivy-${{ matrix.component.name }}.sarif
+          category: trivy-${{ matrix.component.name }}

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,34 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 2 * * 1'
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout; job-level permissions replace the workflow default
+      security-events: write # to upload SARIF results
+      id-token: write # to publish results to the OpenSSF REST API
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Closes two of the remaining gaps versus the HAMi main repo's CI security tooling:

- `scorecard.yaml`: OpenSSF Scorecard analysis, published to the public Scorecard API and uploaded as SARIF to the Security tab. Adapted directly from HAMi's own workflow (branch changed master -> main).
- `image-scanning.yaml`: Trivy image scan. HAMi's `ci-image-scanning.yaml` is tightly coupled to its own build pipeline (a git submodule, `hack/build.sh`, Docker Hub push) which doesn't exist here, so this is a DRA-specific equivalent: builds each of the 3 existing Dockerfiles (webhook, monitor, fake-driver) locally with `push: false, load: true` and Trivy-scans each resulting image, uploading SARIF per component.

Both run on a schedule (scorecard also on push to main), so neither gates PR merges.