### PR TITLE
docs: add HAMi-DRA issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Report a problem encountered while using HAMi-DRA
+labels: bug
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+-->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+- Relevant, time-bounded excerpts from the HAMi-DRA webhook and monitor container logs
+- Relevant, time-bounded excerpts from the API server, scheduler, container runtime, and kubelet logs
+- Relevant, redacted Pod, ResourceClaim, ResourceClaimTemplate, and device-class manifests or events
+- Relevant Helm values and CDI or container-runtime configuration sections
+- Relevant, time-bounded device-driver or kernel output
+
+Before posting, remove or mask credentials, tokens, certificate private keys, GPU or device identifiers, Pod and ResourceClaim identifiers, namespace or node names, internal endpoints, and other sensitive data from configuration and logs.
+
+**Environment**:
+- HAMi-DRA version, commit, image, or Helm chart version:
+- Kubernetes version and enabled DRA feature gates:
+- HAMi version:
+- Device type and driver version:
+- Container runtime and CDI version:
+- cert-manager version or custom certificate configuration:
+- Installation method and relevant Helm configuration:
+- Kernel version from `uname -a`:
+- Others:

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,13 @@
+---
+name: Enhancement Request
+about: Suggest an improvement to HAMi-DRA
+labels: enhancement
+---
+
+<!-- Please use this template for enhancement and feature requests. -->
+
+**What would you like to be added**:
+
+**Why is this needed**:
+
+**Anything else we need to know?**:

--- a/.github/ISSUE_TEMPLATE/good-first.md
+++ b/.github/ISSUE_TEMPLATE/good-first.md
@@ -1,0 +1,23 @@
+---
+name: Good First Issue
+about: Publish a task suitable for a first-time contributor
+labels: "good first issue"
+---
+
+<!-- Please use this template when publishing a good first issue. -->
+
+**Task description**:
+
+**Suggested solution**:
+
+**Who can take this task**:
+
+This issue is intended for a first-time contributor beginning their contribution journey.
+
+**How to take the task**:
+
+Reply to the issue and state that you would like to work on it. A maintainer can assign it to you.
+
+**How to ask for help**:
+
+If you need assistance or have questions, ask in the issue. The issue author or another community member can provide guidance.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,21 @@
+---
+name: Question
+about: Ask a question about HAMi-DRA
+labels: question
+---
+
+**Please provide a detailed description of your question**:
+
+**What have you already tried or investigated?**:
+
+Before posting, include only relevant, time-bounded excerpts and remove or mask credentials, tokens, certificate private keys, device identifiers, workload identifiers, namespace or node names, and internal endpoints.
+
+**Environment**:
+
+- HAMi-DRA version, commit, image, or Helm chart version:
+- Kubernetes version and enabled DRA feature gates:
+- HAMi version:
+- Device type and driver version:
+- Container runtime and CDI version:
+- cert-manager version or certificate configuration:
+- Others:

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -8,6 +8,14 @@ labels: question
 
 **What have you already tried or investigated?**:
 
+**Relevant diagnostics, when applicable**:
+
+- Reproduction steps and deployment context:
+- Relevant, time-bounded logs:
+- Relevant manifests, events, or Helm values:
+- Relevant CDI or container-runtime configuration:
+- Relevant device-driver output:
+
 Before posting, include only relevant, time-bounded excerpts and remove or mask credentials, tokens, certificate private keys, device identifiers, workload identifiers, namespace or node names, and internal endpoints.
 
 **Environment**:


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

/kind documentation

**What this PR does / why we need it**:

Adds concise, repository-specific templates for bug reports, enhancements, good first issues, and questions. This helps reports collect consistent DRA, ResourceClaim, CDI, device, runtime, and reproduction details while keeping project behavior unchanged.

**Which issue(s) this PR fixes**:
Fixes #81

**Special notes for your reviewer**:

This is a documentation-only change containing four issue templates. `.github/PULL_REQUEST_TEMPLATE.md` is intentionally excluded because open PR #77 already adds it. The front matter was parsed locally, uses existing repository labels, and all Markdown files were checked for whitespace errors. Diagnostic prompts request only relevant, time-bounded excerpts and require sensitive identifiers to be masked.

**Does this PR introduce a user-facing change?**:

Yes. Contributors will see HAMi-DRA-specific prompts when opening issues.

**AI Disclosure**:

AI was used only for formatting purposes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added structured issue templates for bug reports, enhancement requests, questions, and good-first contributions.
  * Templates guide contributors to provide relevant problem details, reproduction steps, environment information, diagnostics, rationale, and suggested solutions.
  * Added guidance on contributor eligibility, assignment, and where to seek help.
  * Added reminders to redact sensitive information before submitting issues, helping keep shared diagnostic data safe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->