### PR TITLE
fix: bump Go to 1.26.6 and pin image bases to digests

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache-dependency-path: go.sum
 
       - name: Download dependencies
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache-dependency-path: go.sum
 
       - name: Run golangci-lint
@@ -144,7 +144,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache-dependency-path: go.sum
 
       - name: Run govulncheck

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -14,7 +14,7 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     env:
-      GOTOOLCHAIN: go1.26.5+auto
+      GOTOOLCHAIN: go1.26.6+auto
     
     steps:
       - name: Checkout repository
@@ -48,7 +48,7 @@ jobs:
     name: Run Linter
     runs-on: ubuntu-latest
     env:
-      GOTOOLCHAIN: go1.26.5+auto
+      GOTOOLCHAIN: go1.26.6+auto
     
     steps:
       - name: Checkout repository

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 BUILD_ARCH ?= linux/$(GOARCH)
-GOTOOLCHAIN ?= go1.26.5+auto
+GOTOOLCHAIN ?= go1.26.6+auto
 GOLANGCI_LINT_VERSION ?= v2.5.0
 GOLANGCI_LINT_ARGS ?= --timeout=5m
 

--- a/docker/hami-dra-fake-driver/Dockerfile
+++ b/docker/hami-dra-fake-driver/Dockerfile
@@ -1,5 +1,5 @@
 # Build the fake driver binary
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.6@sha256:0d1d3a794be25f809dd2cb3160d8c73276c4056a9f8242a138e908ddeee7b6b6 AS builder
 
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
@@ -16,6 +16,6 @@ COPY internal/ internal/
 
 RUN go build -ldflags="-s -w" -a -o fake-driver ./cmd/fake-driver && echo "Building GOARCH of $GOARCH.."
 
-FROM alpine:3.22
+FROM alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
 COPY --from=builder /workspace/fake-driver /bin/fake-driver
 ENTRYPOINT ["/bin/fake-driver"]

--- a/docker/hami-dra-monitor/Dockerfile
+++ b/docker/hami-dra-monitor/Dockerfile
@@ -1,5 +1,5 @@
 # Build the monitor binary
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.6@sha256:0d1d3a794be25f809dd2cb3160d8c73276c4056a9f8242a138e908ddeee7b6b6 AS builder
 
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
@@ -21,7 +21,7 @@ COPY pkg/ pkg/
 # Build
 RUN go build -ldflags="-s -w" -a -o monitor cmd/monitor/main.go && echo "Building GOARCH of $GOARCH.."
 
-FROM alpine:3.22
+FROM alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
 RUN adduser -D -u 1000 monitor
 COPY --from=builder /workspace/monitor /bin/monitor
 USER monitor

--- a/docker/hami-dra-webhook/Dockerfile
+++ b/docker/hami-dra-webhook/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.6@sha256:0d1d3a794be25f809dd2cb3160d8c73276c4056a9f8242a138e908ddeee7b6b6 AS builder
 
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
@@ -21,7 +21,7 @@ COPY pkg/ pkg/
 # Build
 RUN go build -ldflags="-s -w" -a -o webhook cmd/webhook/main.go && echo "Building GOARCH of $GOARCH.."
 
-FROM alpine:3.22
+FROM alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
 RUN adduser -D -u 1000 webhook
 COPY --from=builder /workspace/webhook /bin/webhook
 USER webhook

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Project-HAMi/HAMi-DRA
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
Fixes the 24 open Trivy alerts (Go stdlib CVEs fixed in 1.26.6) and pins builder/runtime base images by digest for Scorecard PinnedDependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the application build and validation environment to Go 1.26.6.
  * Pinned container base images to immutable digests for more consistent, reproducible builds.
  * Refreshed runtime image references while retaining the existing Alpine release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->