### PR TITLE
ci: set least-privilege token permissions in release workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "main" ]
     tags: [ 'v*.*.*' ]
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -7,12 +7,14 @@ on:
       - "v*"
 
 permissions:
-  contents: write   # create GitHub Releases & push to gh-pages
-  packages: write   # push OCI chart to GHCR
+  contents: read
 
 jobs:
   helm-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create GitHub Releases & push to gh-pages
+      packages: write   # push OCI chart to GHCR
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Fixes Scorecard TokenPermissions alerts: top-level read-only GITHUB_TOKEN in docker-publish and helm-release, write scopes moved to job level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow security by applying read-only repository permissions by default.
  * Limited elevated write access to only the specific Helm release job that requires it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->