### PR TITLE
fix: use valid CEL negation for nouse-gpuuuid/nouse-gputype selectors

### DIFF
--- a/pkg/webhook/dra/mutating.go
+++ b/pkg/webhook/dra/mutating.go
@@ -222,7 +222,7 @@ func (a *MutatingAdmission) addAnnotationSelectors(resourceclaim *resourceapi.Re
 		noUUIDs := strings.Split(noUUIDStr, ",")
 		exactly.Selectors = append(exactly.Selectors, resourceapi.DeviceSelector{
 			CEL: &resourceapi.CELDeviceSelector{
-				Expression: fmt.Sprintf(`device.attributes["%s"].uuid not in ["%s"]`, draDriverName, strings.Join(noUUIDs, `","`)),
+				Expression: fmt.Sprintf(`!(device.attributes["%s"].uuid in ["%s"])`, draDriverName, strings.Join(noUUIDs, `","`)),
 			},
 		})
 	}
@@ -240,7 +240,7 @@ func (a *MutatingAdmission) addAnnotationSelectors(resourceclaim *resourceapi.Re
 		noUseTypes := strings.Split(noUseTypeStr, ",")
 		exactly.Selectors = append(exactly.Selectors, resourceapi.DeviceSelector{
 			CEL: &resourceapi.CELDeviceSelector{
-				Expression: fmt.Sprintf(`device.attributes["%s"].productName not in ["%s"]`, draDriverName, strings.Join(noUseTypes, `","`)),
+				Expression: fmt.Sprintf(`!(device.attributes["%s"].productName in ["%s"])`, draDriverName, strings.Join(noUseTypes, `","`)),
 			},
 		})
 	}

--- a/pkg/webhook/dra/mutating_test.go
+++ b/pkg/webhook/dra/mutating_test.go
@@ -69,7 +69,7 @@ func TestAddAnnotationSelectors(t *testing.T) {
 				constants.NoUseUUIDAnnotation: "gpu-999,gpu-888",
 			},
 			wantSelectors: []string{
-				`device.attributes["hami-core-gpu.project-hami.io"].uuid not in ["gpu-999","gpu-888"]`,
+				`!(device.attributes["hami-core-gpu.project-hami.io"].uuid in ["gpu-999","gpu-888"])`,
 			},
 		},
 
@@ -99,7 +99,7 @@ func TestAddAnnotationSelectors(t *testing.T) {
 				constants.NoUseTypeAnnotation: "A100,H100",
 			},
 			wantSelectors: []string{
-				`device.attributes["hami-core-gpu.project-hami.io"].productName not in ["A100","H100"]`,
+				`!(device.attributes["hami-core-gpu.project-hami.io"].productName in ["A100","H100"])`,
 			},
 		},
 
@@ -113,9 +113,9 @@ func TestAddAnnotationSelectors(t *testing.T) {
 			},
 			wantSelectors: []string{
 				`device.attributes["hami-core-gpu.project-hami.io"].uuid in ["gpu-123","gpu-456"]`,
-				`device.attributes["hami-core-gpu.project-hami.io"].uuid not in ["gpu-999"]`,
+				`!(device.attributes["hami-core-gpu.project-hami.io"].uuid in ["gpu-999"])`,
 				`device.attributes["hami-core-gpu.project-hami.io"].productName in ["A100"]`,
-				`device.attributes["hami-core-gpu.project-hami.io"].productName not in ["H100"]`,
+				`!(device.attributes["hami-core-gpu.project-hami.io"].productName in ["H100"])`,
 			},
 		},
 		{


### PR DESCRIPTION
CEL has no `not in` operator, so blacklist annotations were always rejected at admission. Generate `!(x in [...])` instead. Fixes #84