### PR TITLE
fix: patch openssl CVEs in runtime images, pin docker/login-action

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -42,7 +42,7 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/docker/hami-dra-fake-driver/Dockerfile
+++ b/docker/hami-dra-fake-driver/Dockerfile
@@ -17,5 +17,7 @@ COPY internal/ internal/
 RUN go build -ldflags="-s -w" -a -o fake-driver ./cmd/fake-driver && echo "Building GOARCH of $GOARCH.."
 
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+# ponytail: pinned digest can lag CVE fixes in apk repos; upgrade at build time to pick up patched packages
+RUN apk update && apk upgrade --no-cache
 COPY --from=builder /workspace/fake-driver /bin/fake-driver
 ENTRYPOINT ["/bin/fake-driver"]

--- a/docker/hami-dra-monitor/Dockerfile
+++ b/docker/hami-dra-monitor/Dockerfile
@@ -25,7 +25,8 @@ COPY pkg/ pkg/
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -a -o monitor cmd/monitor/main.go
 
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
-RUN adduser -D -u 1000 monitor
+# ponytail: pinned digest can lag CVE fixes in apk repos; upgrade at build time to pick up patched packages
+RUN apk update && apk upgrade --no-cache && adduser -D -u 1000 monitor
 COPY --from=builder /workspace/monitor /bin/monitor
 USER monitor
 CMD ["/bin/monitor"]

--- a/docker/hami-dra-webhook/Dockerfile
+++ b/docker/hami-dra-webhook/Dockerfile
@@ -25,7 +25,8 @@ COPY pkg/ pkg/
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -a -o webhook cmd/webhook/main.go
 
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
-RUN adduser -D -u 1000 webhook
+# ponytail: pinned digest can lag CVE fixes in apk repos; upgrade at build time to pick up patched packages
+RUN apk update && apk upgrade --no-cache && adduser -D -u 1000 webhook
 COPY --from=builder /workspace/webhook /bin/webhook
 USER webhook
 CMD ["/bin/webhook"]


### PR DESCRIPTION
- The `alpine:3.24` digest currently pinned in all three Dockerfiles still ships `libssl3`/`libcrypto3` 3.5.7-r0, vulnerable to CVE-2026-14456, CVE-2026-14457, CVE-2026-18798, CVE-2026-54874, CVE-2026-63072 through CVE-2026-63076, and CVE-2026-75803 (fixed in 3.5.8-r0). Added `apk upgrade --no-cache` at build time in the final stage of each Dockerfile so patched packages are picked up without dropping the digest pin.
- `docker/login-action` was bumped from a hash-pinned v3 to `@v4` (tag only) by a prior Dependabot merge, unlike the other actions in `helm-release.yml` which are hash-pinned. Pinned it to match.