### PR TITLE
:art: rename Hygon DCU terminology to HCU

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ helm install hami-dra hami-dra/hami-dra \
 
 Then [use the same as hami](https://project-hami.io/zh/docs/userguide/nvidia-device/examples/use-exclusive-card/).
 
-### Hygon DCU
+### Hygon HCU
 
-For clusters running Hygon DCU with [k8s-dcu-dra-driver](https://github.com/HYGON-AI/k8s-dcu-dra-driver), see [docs/hygon-dcu.md](./docs/hygon-dcu.md).
+For clusters running Hygon HCU with [k8s-hcu-dra-driver](https://github.com/HYGON-AI/k8s-hcu-dra-driver), see [docs/hygon-hcu.md](./docs/hygon-hcu.md).
 
 ## Configuration
 

--- a/charts/hami-dra/templates/_helpers.tpl
+++ b/charts/hami-dra/templates/_helpers.tpl
@@ -88,25 +88,25 @@ groups:
 {{- end }}
 {{- end -}}
 
-{{- define "hami.dra.dcu.deviceClassName" -}}
-{{- if .Values.drivers.dcu.deviceClassName -}}
-{{- .Values.drivers.dcu.deviceClassName -}}
+{{- define "hami.dra.hcu.deviceClassName" -}}
+{{- if .Values.drivers.hcu.deviceClassName -}}
+{{- .Values.drivers.hcu.deviceClassName -}}
 {{- else -}}
-{{- .Values.dcuDeviceClassName -}}
+{{- .Values.hcuDeviceClassName -}}
 {{- end -}}
 {{- end -}}
 
-{{- define "hami.dra.dcu.driverName" -}}
-{{- if .Values.drivers.dcu.driverName -}}
-{{- .Values.drivers.dcu.driverName -}}
+{{- define "hami.dra.hcu.driverName" -}}
+{{- if .Values.drivers.hcu.driverName -}}
+{{- .Values.drivers.hcu.driverName -}}
 {{- else -}}
-{{- .Values.dcuDraDriverName -}}
+{{- .Values.hcuDraDriverName -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "hami.dra.webhook.deviceClassName" -}}
 {{- if eq (include "hami.dra.webhook.deviceVendor" .) "hygon" -}}
-{{- include "hami.dra.dcu.deviceClassName" . -}}
+{{- include "hami.dra.hcu.deviceClassName" . -}}
 {{- else if and .Values.drivers.fake.enabled (not .Values.drivers.nvidia.enabled) -}}
 {{- .Values.drivers.fake.deviceClassName -}}
 {{- else -}}
@@ -116,7 +116,7 @@ groups:
 
 {{- define "hami.dra.webhook.driverName" -}}
 {{- if eq (include "hami.dra.webhook.deviceVendor" .) "hygon" -}}
-{{- include "hami.dra.dcu.driverName" . -}}
+{{- include "hami.dra.hcu.driverName" . -}}
 {{- else if and .Values.drivers.fake.enabled (not .Values.drivers.nvidia.enabled) -}}
 {{- .Values.drivers.fake.driverName -}}
 {{- else -}}

--- a/charts/hami-dra/templates/webhook/device-config.yaml
+++ b/charts/hami-dra/templates/webhook/device-config.yaml
@@ -227,13 +227,13 @@ data:
       resourceMemoryName: {{ .Values.mluResourceMem }}
       resourceCoreName: {{ .Values.mluResourceCores }}
     hygon:
-      resourceCountName: {{ .Values.dcuResourceName }}
-      resourceMemoryName: {{ .Values.dcuResourceMem }}
-      resourceCoreName: {{ .Values.dcuResourceCores }}
-      deviceClassName: {{ include "hami.dra.dcu.deviceClassName" . }}
-      draDriverName: {{ include "hami.dra.dcu.driverName" . }}
-      requestName: dcu
-      referenceComputeUnits: {{ .Values.dcuReferenceComputeUnits }}
+      resourceCountName: {{ .Values.hcuResourceName }}
+      resourceMemoryName: {{ .Values.hcuResourceMem }}
+      resourceCoreName: {{ .Values.hcuResourceCores }}
+      deviceClassName: {{ include "hami.dra.hcu.deviceClassName" . }}
+      draDriverName: {{ include "hami.dra.hcu.driverName" . }}
+      requestName: hcu
+      referenceComputeUnits: {{ .Values.hcuReferenceComputeUnits }}
     vendor: {{ include "hami.dra.webhook.deviceVendor" . }}
     metax:
       resourceCountName: "metax-tech.com/gpu"

--- a/charts/hami-dra/values.yaml
+++ b/charts/hami-dra/values.yaml
@@ -22,16 +22,16 @@ mluResourceName: "cambricon.com/vmlu"
 mluResourceMem: "cambricon.com/mlu.smlu.vmemory"
 mluResourceCores: "cambricon.com/mlu.smlu.vcore"
 
-# Hygon DCU parameters (webhook when deviceVendor=hygon)
-dcuResourceName: "hygon.com/dcunum"
-dcuResourceMem: "hygon.com/dcumem"
-dcuResourceCores: "hygon.com/dcucores"
-dcuDeviceClassName: dra.hygon.com
-dcuDraDriverName: dra.hygon.com
-# When Pod requests hygon.com/dcucores (percentage), set to one card's total
+# Hygon HCU parameters (webhook when deviceVendor=hygon)
+hcuResourceName: "hygon.com/hcunum"
+hcuResourceMem: "hygon.com/hcumem"
+hcuResourceCores: "hygon.com/hcucores"
+hcuDeviceClassName: dra.hygon.com
+hcuDraDriverName: dra.hygon.com
+# When Pod requests hygon.com/hcucores (percentage), set to one card's total
 # compute units from: kubectl get resourceslice -o yaml
-# Whole-card only (hygon.com/dcunum without dcumem/dcucores) can leave 0.
-dcuReferenceComputeUnits: 0
+# Whole-card only (hygon.com/hcunum without hcumem/hcucores) can leave 0.
+hcuReferenceComputeUnits: 0
 deviceVendor: nvidia  # nvidia | hygon
 
 # Metax sGPU Parameters
@@ -227,10 +227,10 @@ drivers:
       # Optional inline override. When empty, the chart renders a built-in default:
       # 8 fake NVIDIA A100-SXM4-80GB devices on every node.
       inlineData: ""
-  dcu:
-    # Reserved; no DCU driver template in this chart. Deploy k8s-dcu-dra-driver separately.
+  hcu:
+    # Reserved; no HCU driver template in this chart. Deploy k8s-hcu-dra-driver separately.
     enabled: false
     # Override DeviceClass/driver name in webhook config only.
-    # Leave empty to use dcuDeviceClassName / dcuDraDriverName.
+    # Leave empty to use hcuDeviceClassName / hcuDraDriverName.
     deviceClassName: ""
     driverName: ""

--- a/docs/hygon-hcu.md
+++ b/docs/hygon-hcu.md
@@ -1,13 +1,13 @@
-# Hygon DCU
+# Hygon HCU
 
-Deploy HAMi-DRA webhook for Hygon DCU clusters that already run [k8s-dcu-dra-driver](https://github.com/HYGON-AI/k8s-dcu-dra-driver).
+Deploy HAMi-DRA webhook for Hygon HCU clusters that already run [k8s-hcu-dra-driver](https://github.com/HYGON-AI/k8s-hcu-dra-driver).
 
-This chart deploys only the mutating/validating webhook and TLS certificates. The DCU DRA driver and `DeviceClass` (`dra.hygon.com`) must be deployed separately via k8s-dcu-dra-driver.
+This chart deploys only the mutating/validating webhook and TLS certificates. The HCU DRA driver and `DeviceClass` (`dra.hygon.com`) must be deployed separately via k8s-hcu-dra-driver.
 
 ## Prerequisites
 
 1. Kubernetes with DRA enabled (same requirements as the main chart).
-2. [k8s-dcu-dra-driver](https://github.com/HYGON-AI/k8s-dcu-dra-driver) deployed; `DeviceClass` `dra.hygon.com` must exist.
+2. [k8s-hcu-dra-driver](https://github.com/HYGON-AI/k8s-hcu-dra-driver) deployed; `DeviceClass` `dra.hygon.com` must exist.
 3. [cert-manager](https://cert-manager.io/docs/installation/) installed.
 4. `hami-dra-webhook` image built and reachable from all nodes (override `webhook.image.*` if not using the default registry).
 
@@ -46,25 +46,25 @@ helm upgrade hami-dra ./charts/hami-dra -n hami-system \
 
 | Value | Recommended | Notes |
 |-------|-------------|-------|
-| `deviceVendor` | `hygon` | Switches webhook to Hygon DCU resource names and `dra.hygon.com` driver. |
+| `deviceVendor` | `hygon` | Switches webhook to Hygon HCU resource names and `dra.hygon.com` driver. |
 | `drivers.nvidia.enabled` | `false` | Do not deploy the NVIDIA DRA driver DaemonSet. |
-| `drivers.dcu.deviceClassName` / `driverName` | empty (default) | Optional overrides for webhook config; falls back to `dcuDeviceClassName` / `dcuDraDriverName`. Does not deploy a driver. |
-| `monitor.enabled` | `false` | Monitor is NVIDIA-oriented today; disable for DCU-only clusters. |
+| `drivers.hcu.deviceClassName` / `driverName` | empty (default) | Optional overrides for webhook config; falls back to `hcuDeviceClassName` / `hcuDraDriverName`. Does not deploy a driver. |
+| `monitor.enabled` | `false` | Monitor is NVIDIA-oriented today; disable for HCU-only clusters. |
 | `certs.certManager.enabled` | `true` (default) | Uses cert-manager for webhook TLS. |
 
-DCU resource names and driver identifiers use chart defaults in `values.yaml` (no override needed in most cases):
+HCU resource names and driver identifiers use chart defaults in `values.yaml` (no override needed in most cases):
 
 ```yaml
-dcuResourceName: "hygon.com/dcunum"
-dcuResourceMem: "hygon.com/dcumem"
-dcuResourceCores: "hygon.com/dcucores"
-dcuDeviceClassName: dra.hygon.com
-dcuDraDriverName: dra.hygon.com
+hcuResourceName: "hygon.com/hcunum"
+hcuResourceMem: "hygon.com/hcumem"
+hcuResourceCores: "hygon.com/hcucores"
+hcuDeviceClassName: dra.hygon.com
+hcuDraDriverName: dra.hygon.com
 ```
 
-### Fractional compute (`hygon.com/dcucores`)
+### Fractional compute (`hygon.com/hcucores`)
 
-When Pods request compute as a percentage via `hygon.com/dcucores`, set `dcuReferenceComputeUnits` to one card's total compute units from the cluster:
+When Pods request compute as a percentage via `hygon.com/hcucores`, set `hcuReferenceComputeUnits` to one card's total compute units from the cluster:
 
 ```bash
 kubectl get resourceslice -o yaml
@@ -77,17 +77,17 @@ helm upgrade hami-dra ./charts/hami-dra -n hami-system \
   --set deviceVendor=hygon \
   --set drivers.nvidia.enabled=false \
   --set monitor.enabled=false \
-  --set dcuReferenceComputeUnits=128
+  --set hcuReferenceComputeUnits=128
 ```
 
-For whole-card requests only (`hygon.com/dcunum` without `dcumem` / `dcucores`), leave `dcuReferenceComputeUnits` at `0` (default).
+For whole-card requests only (`hygon.com/hcunum` without `hcumem` / `hcucores`), leave `hcuReferenceComputeUnits` at `0` (default).
 
 ## What gets deployed
 
-| Component | Hygon DCU install | Default NVIDIA install |
+| Component | Hygon HCU install | Default NVIDIA install |
 |-----------|-------------------|------------------------|
 | hami-dra-webhook | Yes (Hygon vendor) | Yes (NVIDIA vendor) |
 | cert-manager resources | Yes | Yes |
 | NVIDIA DRA driver DaemonSet | No | Yes |
 | hami-dra-monitor | No | Yes |
-| DCU DRA driver | External (k8s-dcu-dra-driver) | N/A |
+| HCU DRA driver | External (k8s-hcu-dra-driver) | N/A |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -95,7 +95,7 @@ type Config struct {
 	Hygon  HygonConfig  `yaml:"hygon"`
 }
 
-// HygonConfig holds DCU DRA settings for k8s-dcu-dra-driver (dra.hygon.com).
+// HygonConfig holds HCU DRA settings for k8s-hcu-dra-driver (dra.hygon.com).
 type HygonConfig struct {
 	ResourceCountName  string `yaml:"resourceCountName"`
 	ResourceMemoryName string `yaml:"resourceMemoryName"`
@@ -109,7 +109,7 @@ type HygonConfig struct {
 	UseTypeAnnotation   string `yaml:"useTypeAnnotation"`
 	NoUseTypeAnnotation string `yaml:"noUseTypeAnnotation"`
 
-	// ReferenceComputeUnits converts hygon.com/dcucores (percentage) to absolute cores for DRA.
+	// ReferenceComputeUnits converts hygon.com/hcucores (percentage) to absolute cores for DRA.
 	ReferenceComputeUnits int64 `yaml:"referenceComputeUnits"`
 }
 

--- a/pkg/config/dra_device.go
+++ b/pkg/config/dra_device.go
@@ -44,7 +44,7 @@ type DRADeviceConfig struct {
 	UseTypeAnnotation   string
 	NoUseTypeAnnotation string
 
-	// ReferenceComputeUnits converts hygon.com/dcucores percentage to absolute cores when > 0.
+	// ReferenceComputeUnits converts hygon.com/hcucores percentage to absolute cores when > 0.
 	ReferenceComputeUnits int64
 }
 
@@ -77,7 +77,7 @@ func (c *DRADeviceConfig) ConvertMemory(memQty resource.Quantity) resource.Quant
 
 func (c *DRADeviceConfig) ConvertCores(coreQty resource.Quantity) (resource.Quantity, error) {
 	if c.DeviceType == constants.HygonDeviceType && c.ReferenceComputeUnits <= 0 {
-		return resource.Quantity{}, fmt.Errorf("referenceComputeUnits must be configured to convert hygon.com/dcucores requests")
+		return resource.Quantity{}, fmt.Errorf("referenceComputeUnits must be configured to convert hygon.com/hcucores requests")
 	}
 	if c.ReferenceComputeUnits > 0 {
 		pct := coreQty.Value()
@@ -115,12 +115,12 @@ func draDeviceFromHygon(c *HygonConfig) *DRADeviceConfig {
 		c = &HygonConfig{}
 	}
 	cfg := &DRADeviceConfig{
-		ResourceCountName:     firstNonEmpty(c.ResourceCountName, "hygon.com/dcunum"),
-		ResourceMemoryName:    firstNonEmpty(c.ResourceMemoryName, "hygon.com/dcumem"),
-		ResourceCoreName:      firstNonEmpty(c.ResourceCoreName, "hygon.com/dcucores"),
+		ResourceCountName:     firstNonEmpty(c.ResourceCountName, "hygon.com/hcunum"),
+		ResourceMemoryName:    firstNonEmpty(c.ResourceMemoryName, "hygon.com/hcumem"),
+		ResourceCoreName:      firstNonEmpty(c.ResourceCoreName, "hygon.com/hcucores"),
 		DeviceClassName:       firstNonEmpty(c.DeviceClassName, constants.HygonDraDriver),
 		DraDriverName:         firstNonEmpty(c.DraDriverName, constants.HygonDraDriver),
-		RequestName:           firstNonEmpty(c.RequestName, "dcu"),
+		RequestName:           firstNonEmpty(c.RequestName, "hcu"),
 		DeviceType:            constants.HygonDeviceType,
 		UseUUIDAnnotation:     firstNonEmpty(c.UseUUIDAnnotation, constants.HygonUseUUIDAnnotation),
 		NoUseUUIDAnnotation:   firstNonEmpty(c.NoUseUUIDAnnotation, constants.HygonNoUseUUIDAnnotation),

--- a/pkg/config/dra_device_test.go
+++ b/pkg/config/dra_device_test.go
@@ -27,9 +27,9 @@ import (
 func TestDRADeviceHygonDefaults(t *testing.T) {
 	cfg, err := (&Config{}).DRADevice(VendorHygon)
 	assert.NoError(t, err)
-	assert.Equal(t, "hygon.com/dcunum", cfg.ResourceCountName)
+	assert.Equal(t, "hygon.com/hcunum", cfg.ResourceCountName)
 	assert.Equal(t, "dra.hygon.com", cfg.EffectiveDeviceClassName())
-	assert.Equal(t, "dcu", cfg.RequestName)
+	assert.Equal(t, "hcu", cfg.RequestName)
 }
 
 func TestConvertCoresWithReferenceComputeUnits(t *testing.T) {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -29,12 +29,12 @@ const (
 	NvidiaDeviceType = "hami-gpu"
 
 	HygonDraDriver  = "dra.hygon.com"
-	HygonDeviceType = "dcu"
+	HygonDeviceType = "hcu"
 
 	HygonUseUUIDAnnotation   = "hygon.com/use-gpuuuid"
 	HygonNoUseUUIDAnnotation = "hygon.com/nouse-gpuuuid"
-	HygonUseTypeAnnotation   = "hygon.com/use-dcutype"
-	HygonNoUseTypeAnnotation = "hygon.com/nouse-dcutype"
+	HygonUseTypeAnnotation   = "hygon.com/use-hcutype"
+	HygonNoUseTypeAnnotation = "hygon.com/nouse-hcutype"
 
 	DraLabel = "hami.io/dra"
 

--- a/pkg/webhook/dra/mutating_test.go
+++ b/pkg/webhook/dra/mutating_test.go
@@ -233,7 +233,7 @@ func TestAddAnnotationSelectorsHygon(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				constants.HygonUseUUIDAnnotation: "DCU-123",
+				constants.HygonUseUUIDAnnotation: "HCU-123",
 				constants.HygonUseTypeAnnotation: "K100",
 			},
 		},
@@ -245,7 +245,7 @@ func TestAddAnnotationSelectorsHygon(t *testing.T) {
 			Devices: resourceapi.DeviceClaim{
 				Requests: []resourceapi.DeviceRequest{
 					{
-						Name: "dcu",
+						Name: "hcu",
 						Exactly: &resourceapi.ExactDeviceRequest{
 							Selectors: []resourceapi.DeviceSelector{},
 						},
@@ -258,7 +258,7 @@ func TestAddAnnotationSelectorsHygon(t *testing.T) {
 	require.NoError(t, admission.addAnnotationSelectors(claim, pod))
 	selectors := claim.Spec.Devices.Requests[0].Exactly.Selectors
 	assert.Len(t, selectors, 2)
-	assert.Equal(t, `device.attributes["dra.hygon.com"].uuid in ["DCU-123"]`, selectors[0].CEL.Expression)
+	assert.Equal(t, `device.attributes["dra.hygon.com"].uuid in ["HCU-123"]`, selectors[0].CEL.Expression)
 	assert.Equal(t, `device.attributes["dra.hygon.com"].productName in ["K100"]`, selectors[1].CEL.Expression)
 }
 


### PR DESCRIPTION
Align resource names, annotations, Helm values, and docs with
k8s-hcu-dra-driver (hygon.com/hcu*, requestName=hcu).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Hygon device configuration has been renamed from DCU to HCU.
  - Resource names, request names, annotations, Helm values, and driver references now use HCU terminology.
  - Existing DCU-specific configuration keys and identifiers must be updated.

- **Documentation**
  - Installation and Hygon documentation now reference the HCU DRA driver and HCU resource parameters.
  - Configuration examples and deployment descriptions have been updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->